### PR TITLE
feat: setup daisy, tailwind configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "aws-cdk-lib": "2.110.1",
     "constructs": "10.3.0",
     "cz-conventional-changelog": "3.3.0",
+    "daisyui": "^4.6.2",
     "devmoji": "2.3.0",
     "eslint": "8.54.0",
     "eslint-config-prettier": "9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   cz-conventional-changelog:
     specifier: 3.3.0
     version: 3.3.0(typescript@5.3.2)
+  daisyui:
+    specifier: ^4.6.2
+    version: 4.6.2(postcss@8.4.31)
   devmoji:
     specifier: 2.3.0
     version: 2.3.0
@@ -4785,6 +4788,13 @@ packages:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
     dev: true
 
+  /css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+    dev: true
+
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -4796,6 +4806,11 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /culori@3.3.0:
+    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /cz-conventional-changelog@3.3.0(typescript@5.3.2):
@@ -4812,6 +4827,18 @@ packages:
       '@commitlint/load': 18.4.3(typescript@5.3.2)
     transitivePeerDependencies:
       - typescript
+    dev: true
+
+  /daisyui@4.6.2(postcss@8.4.31):
+    resolution: {integrity: sha512-LBIbI76wVVRCQt1Uis2Y2/PRdGfMkNMFsHOjfpav8n7SamwRwPOCiNUClIrnX2jerWW3mLZlzRMCnQfxmGEjow==}
+    engines: {node: '>=16.9.0'}
+    dependencies:
+      css-selector-tokenizer: 0.8.0
+      culori: 3.3.0
+      picocolors: 1.0.0
+      postcss-js: 4.0.1(postcss@8.4.31)
+    transitivePeerDependencies:
+      - postcss
     dev: true
 
   /dargs@7.0.0:
@@ -5676,6 +5703,10 @@ packages:
     hasBin: true
     dependencies:
       strnum: 1.0.5
+    dev: true
+
+  /fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
     dev: true
 
   /fastq@1.15.0:

--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" data-theme="zotmeet-theme">
+  <body data-sveltekit-preload-data="hover" data-theme="emerald">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -5,7 +5,7 @@
   <input
     type="text"
     placeholder="Type here"
-    class="input input-bordered input-primary w-full max-w-xs"
+    class="input input-bordered input-primary w-full max-w-xs bg-slate-base"
   />
 </div>
 

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div>
+  <input type="text" placeholder="Type here" class="input w-full max-w-xs" />
+</div>

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2,5 +2,22 @@
 </script>
 
 <div>
-  <input type="text" placeholder="Type here" class="input w-full max-w-xs" />
+  <input
+    type="text"
+    placeholder="Type here"
+    class="input input-bordered input-primary w-full max-w-xs"
+  />
+</div>
+
+<div class="card w-96 bg-base-100 shadow-xl">
+  <figure>
+    <img src="https://daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.jpg" alt="Shoes" />
+  </figure>
+  <div class="card-body">
+    <h2 class="card-title">Shoes!</h2>
+    <p>If a dog chews shoes whose shoes does he choose?</p>
+    <div class="card-actions justify-end">
+      <button class="btn btn-primary">Buy Now</button>
+    </div>
+  </div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,8 @@ export default {
       {
         emerald: {
           ...emerald["emerald"],
+          primary: "#367BFB",
+          secondary: "#65CC8A",
         },
       },
     ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,12 @@
 // @ts-check
 import { join } from "path";
 
-import { skeleton } from "@skeletonlabs/tw-plugin";
+// import { skeleton } from "@skeletonlabs/tw-plugin";
 import forms from "@tailwindcss/forms";
 import daisyui from "daisyui";
+import emerald from "daisyui/src/theming/themes";
 
-import { zotmeetTheme } from "./theme";
+// import { zotmeetTheme } from "./theme";
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -22,8 +23,17 @@ export default {
   plugins: [
     daisyui,
     forms,
-    skeleton({
-      themes: { custom: [zotmeetTheme] },
-    }),
+    // skeleton({
+    //   themes: { custom: [zotmeetTheme] },
+    // }),
   ],
+  daisyui: {
+    themes: [
+      {
+        light: {
+          emerald,
+        },
+      },
+    ],
+  },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,20 @@ export default {
     join(require.resolve("@skeletonlabs/skeleton"), "../**/*.{html,js,svelte,ts}"),
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {},
+    },
+    default: "daisy",
+  },
+  daisyui: {
+    themes: [
+      "emerald",
+      {
+        emerald: {
+          ...emerald["emerald"],
+        },
+      },
+    ],
   },
   plugins: [
     daisyui,
@@ -27,13 +40,4 @@ export default {
     //   themes: { custom: [zotmeetTheme] },
     // }),
   ],
-  daisyui: {
-    themes: [
-      {
-        light: {
-          emerald,
-        },
-      },
-    ],
-  },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ import { join } from "path";
 
 import { skeleton } from "@skeletonlabs/tw-plugin";
 import forms from "@tailwindcss/forms";
+import daisyui from "daisyui";
 
 import { zotmeetTheme } from "./theme";
 
@@ -19,6 +20,7 @@ export default {
     extend: {},
   },
   plugins: [
+    daisyui,
     forms,
     skeleton({
       themes: { custom: [zotmeetTheme] },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,17 @@ export default {
   ],
   theme: {
     extend: {
-      colors: {},
+      colors: {
+        gray: {
+          light: "#F3F4F6" /* maps to gray-100 */,
+          base: "#D1D5DB" /* gray-300 */,
+          medium: "#9CA3AF" /* gray-400 */,
+          dark: "#1F2937" /* gray-800 */,
+        },
+        slate: {
+          base: "#CBD5E1" /* slate-300 */,
+        },
+      },
     },
     default: "daisy",
   },


### PR DESCRIPTION
## Summary
1. Adds DaisyUI
2. Enabled Daisy's Emerald theme, according to the Figma specs
3. Added explicit tailwind colors for gray/slate, such as `gray-dark` or `slate-base`
4. Skeleton is disabled, not deleted
5. Adds a playground route, for fiddling with components (can remove in final commit)

## Screenshots
<img width="1728" alt="Screenshot 2024-02-09 at 2 10 55 AM" src="https://github.com/icssc/ZotMeet/assets/100006999/0fe659dd-64e7-4649-84a1-a36126497fbb">

<img width="965" alt="Screenshot 2024-02-09 at 2 11 18 AM" src="https://github.com/icssc/ZotMeet/assets/100006999/cc6f23ac-30f3-49e3-b00a-164f774cec5d">

Things to note:
1. The theme (emerald) matches up (cards look the same), indicating that the theme is indeed being applied
2. The input's background is of `bg-slate-base`, indicating the palette is indeed working