### PR TITLE
Fix Mobile Calendar Drag Selection

### DIFF
--- a/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
@@ -10,7 +10,7 @@
   class:day-selected={calendarDay.isSelected}
   class:day-highlighted={isHighlighted}
   data-day={calendarDay.getDay()}
-  data-month={calendarDay.getMonth() + 1}
+  data-month={calendarDay.getMonth()}
   data-year={calendarDay.getYear()}
   data-selected={calendarDay.isSelected}
 >

--- a/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
   import type { ZotDate } from "$lib/utils/ZotDate";
-  import { cn } from "$lib/utils/utils";
 
   export let isHighlighted: boolean | null;
   export let calendarDay: ZotDate;
 </script>
 
 <p
-  class={cn(
-    "flex-center relative aspect-square h-8 w-8 text-base font-medium text-gray-dark md:h-12 md:w-12 md:text-xl",
-    calendarDay.isSelected &&
-      "rounded-lg bg-primary text-gray-light md:rounded-xl md:drop-shadow-[0_0px_16px_rgba(55,124,251,0.4)]",
-    isHighlighted && "rounded-lg bg-slate-base text-gray-dark drop-shadow-none md:rounded-xl",
-  )}
+  class="flex-center relative aspect-square h-8 w-8 text-base font-medium text-gray-dark md:h-12 md:w-12 md:text-xl"
+  class:day-selected={calendarDay.isSelected}
+  class:day-highlighted={isHighlighted}
   data-day={calendarDay.getDay()}
   data-month={calendarDay.getMonth() + 1}
   data-year={calendarDay.getYear()}
@@ -20,3 +16,13 @@
 >
   {calendarDay.getDay()}
 </p>
+
+<style lang="postcss">
+  .day-selected {
+    @apply rounded-lg bg-primary text-gray-light md:rounded-xl md:drop-shadow-[0_0px_16px_rgba(55,124,251,0.4)];
+  }
+
+  .day-highlighted {
+    @apply rounded-lg bg-slate-base text-gray-dark drop-shadow-none md:rounded-xl;
+  }
+</style>

--- a/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
@@ -14,7 +14,7 @@
     isHighlighted && "rounded-lg bg-slate-base text-gray-dark drop-shadow-none md:rounded-xl",
   )}
   data-day={calendarDay.getDay()}
-  data-month={calendarDay.getMonth()}
+  data-month={calendarDay.getMonth() + 1}
   data-year={calendarDay.getYear()}
   data-selected={calendarDay.isSelected}
 >

--- a/src/lib/utils/ZotDate.ts
+++ b/src/lib/utils/ZotDate.ts
@@ -145,7 +145,7 @@ export class ZotDate {
     const isSelected = element.getAttribute("data-selected") === "true";
 
     if ([day, month, year, isSelected].every((attr) => !Number.isNaN(attr) && attr !== null)) {
-      const newDay = new Date(`${month}-${day}-${year}`);
+      const newDay = new Date(year, month, day);
       return new ZotDate(newDay, isSelected);
     }
 


### PR DESCRIPTION
### Summary

- [X] Fixed mobile dragging on calendar page
![2024-02-27 03 14 43](https://github.com/icssc/ZotMeet/assets/37647466/b7b9c2ae-36ac-4ef0-a38a-7377d9529d4c)

- [X] Fixed visual bug where shadows persisted when de-selecting dates.
Before:
![SCR-20240227-dter](https://github.com/icssc/ZotMeet/assets/37647466/60d8d12d-0f76-466e-8605-4b7333318a69)
After:
![SCR-20240227-dsoj](https://github.com/icssc/ZotMeet/assets/37647466/8b6a3a5f-1c6e-4ac5-8b2b-bf88fa18f42b)

- [X] Works on iOS mobile on Chrome & Safari, as well as Chromium browser emulator.
![IMG_917A68B17554-1](https://github.com/icssc/ZotMeet/assets/37647466/0160de97-db58-4850-9137-9f0d3f3f569e)

Closes #49