### PR TITLE
Remove future functionality from UI

### DIFF
--- a/src/lib/components/navigation/shared/NavButton.svelte
+++ b/src/lib/components/navigation/shared/NavButton.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let href: string;
+  export let text: string;
+</script>
+
+<a {href}>
+  <button
+    class="btn h-12 w-full justify-start space-x-3 border-none bg-transparent text-xl font-normal shadow-none md:text-lg"
+  >
+    <slot />
+    <!-- Icon -->
+    <p>{text}</p>
+  </button>
+</a>

--- a/src/lib/components/navigation/shared/NavButtons.svelte
+++ b/src/lib/components/navigation/shared/NavButtons.svelte
@@ -1,32 +1,21 @@
 <script lang="ts">
+  import NavButton from "./NavButton.svelte";
+
   import AddBoxOutlineIcon from "~icons/material-symbols/add-box-outline";
   import CalendarSearchOutlineIcon from "~icons/mdi/calendar-search-outline";
   import SettingsOutline from "~icons/mdi/settings-outline";
 </script>
 
 <div class="flex flex-col gap-y-2 border-t-2 px-6 pt-6 text-gray-600 sm:px-8 md:border-0 md:p-0">
-  <a href="/">
-    <button
-      class="btn h-12 w-full justify-start space-x-3 border-none bg-transparent text-xl font-normal shadow-none md:text-lg"
-    >
-      <AddBoxOutlineIcon class="h-7 w-7" />
-      <p>New Meeting</p>
-    </button>
-  </a>
-  <a href="/summary">
-    <button
-      class="btn h-12 w-full justify-start space-x-3 border-none bg-transparent text-xl font-normal shadow-none md:text-lg"
-    >
-      <CalendarSearchOutlineIcon class="h-7 w-7" />
-      <p>Summary</p>
-    </button>
-  </a>
-  <a href="/settings">
-    <button
-      class="btn h-12 w-full justify-start space-x-3 border-none bg-transparent text-xl font-normal shadow-none md:text-lg"
-    >
-      <SettingsOutline class="h-7 w-7" />
-      <p>Settings</p>
-    </button>
-  </a>
+  <NavButton text="New Meeting" , href="/">
+    <AddBoxOutlineIcon class="h-7 w-7" />
+  </NavButton>
+
+  <NavButton text="Summary" , href="/summary">
+    <CalendarSearchOutlineIcon class="h-7 w-7" />
+  </NavButton>
+
+  <NavButton text="Settings" , href="/settings">
+    <SettingsOutline class="h-7 w-7" />
+  </NavButton>
 </div>

--- a/src/lib/components/navigation/shared/NavButtons.svelte
+++ b/src/lib/components/navigation/shared/NavButtons.svelte
@@ -3,7 +3,7 @@
 
   import AddBoxOutlineIcon from "~icons/material-symbols/add-box-outline";
   import CalendarSearchOutlineIcon from "~icons/mdi/calendar-search-outline";
-  import SettingsOutline from "~icons/mdi/settings-outline";
+  // import SettingsOutline from "~icons/mdi/settings-outline";
 </script>
 
 <div class="flex flex-col gap-y-2 border-t-2 px-6 pt-6 text-gray-600 sm:px-8 md:border-0 md:p-0">
@@ -15,7 +15,7 @@
     <CalendarSearchOutlineIcon class="h-7 w-7" />
   </NavButton>
 
-  <NavButton text="Settings" , href="/settings">
+  <!-- <NavButton text="Settings" , href="/settings">
     <SettingsOutline class="h-7 w-7" />
-  </NavButton>
+  </NavButton> -->
 </div>

--- a/src/lib/components/navigation/shared/NavButtons.svelte
+++ b/src/lib/components/navigation/shared/NavButtons.svelte
@@ -7,11 +7,11 @@
 </script>
 
 <div class="flex flex-col gap-y-2 border-t-2 px-6 pt-6 text-gray-600 sm:px-8 md:border-0 md:p-0">
-  <NavButton text="New Meeting" , href="/">
+  <NavButton text="New Meeting" href="/">
     <AddBoxOutlineIcon class="h-7 w-7" />
   </NavButton>
 
-  <NavButton text="Summary" , href="/summary">
+  <NavButton text="Summary" href="/summary">
     <CalendarSearchOutlineIcon class="h-7 w-7" />
   </NavButton>
 

--- a/src/lib/components/summary/ScheduledMeetings/ScheduledMeetingCard.svelte
+++ b/src/lib/components/summary/ScheduledMeetings/ScheduledMeetingCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import AvailabilityIndicator from "$lib/components/summary/ScheduledMeetings/AvailabilityIndicator.svelte";
+  // import AvailabilityIndicator from "$lib/components/summary/ScheduledMeetings/AvailabilityIndicator.svelte";
   import type { ScheduledMeeting } from "$lib/types/meetings";
   import { convertTo12HourFormat } from "$lib/utils/summary-helpers";
   import MaterialSymbolsGroupsOutline from "~icons/material-symbols/groups-outline";
@@ -34,7 +34,7 @@
         </p>
       </div>
     </div>
-    <AvailabilityIndicator {meeting} />
+    <!-- <AvailabilityIndicator {meeting} /> -->
   </div>
 </div>
 

--- a/src/lib/components/summary/UnscheduledMeetings/UnscheduledMeetingsList.svelte
+++ b/src/lib/components/summary/UnscheduledMeetings/UnscheduledMeetingsList.svelte
@@ -46,7 +46,7 @@
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 p-1">
+        <!-- <div class="flex items-center gap-2 p-1">
           <div
             class:bg-success={meeting.hasIndicated}
             class:bg-slate-400={!meeting.hasIndicated}
@@ -61,7 +61,7 @@
               NOT INDICATED
             {/if}
           </span>
-        </div>
+        </div> -->
       </div>
     </div>
   {/each}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
   <Navbar />
 
   <main
-    class="flex max-h-[calc(100vh-1.5rem)] w-full flex-col gap-y-5 overflow-x-clip border-t-2 bg-white px-2 pb-6 md:gap-y-6 md:overflow-y-auto md:rounded-tl-xl md:px-4"
+    class="flex h-[calc(100vh-1.5rem)] w-full flex-col gap-y-5 overflow-x-clip border-t-2 bg-white px-2 pb-6 md:gap-y-6 md:overflow-y-auto md:rounded-tl-xl md:px-4"
   >
     <slot />
   </main>

--- a/src/routes/summary/+page.svelte
+++ b/src/routes/summary/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import GroupCarousel from "$lib/components/summary/GroupsCarousel.svelte";
+  // import GroupCarousel from "$lib/components/summary/GroupsCarousel.svelte";
   import ScheduledMeetingsList from "$lib/components/summary/ScheduledMeetings/ScheduledMeetingsList.svelte";
   import UnscheduledMeetingsList from "$lib/components/summary/UnscheduledMeetings/UnscheduledMeetingsList.svelte";
 
@@ -9,10 +9,10 @@
 <main
   class="flex min-h-screen w-full flex-col gap-5 overflow-x-clip border-t-[1px] border-gray-300 bg-gray-100 px-2 pb-20 pt-6 md:max-h-[calc(100vh-1.5rem)] md:min-h-0 md:overflow-y-auto md:rounded-tl-xl lg:px-4"
 >
-  <div class="flex flex-col gap-2 px-4 lg:px-16">
+  <!-- <div class="flex flex-col gap-2 px-4 lg:px-16">
     <h2 class="font-montserrat text-xl font-semibold text-gray-800 lg:text-3xl">Groups</h2>
     <GroupCarousel />
-  </div>
+  </div> -->
   <div
     class="flex flex-col gap-4 rounded-xl border-[1px] border-gray-300 bg-gradient-to-tr from-[rgba(55,124,251,0.05)] to-[rgba(246,128,103,0.05)] p-2 pt-4 lg:px-14"
   >

--- a/src/routes/summary/+page.svelte
+++ b/src/routes/summary/+page.svelte
@@ -6,51 +6,47 @@
   let currentTab: number = 0;
 </script>
 
-<main
-  class="flex min-h-screen w-full flex-col gap-5 overflow-x-clip border-t-[1px] border-gray-300 bg-gray-100 px-2 pb-20 pt-6 md:max-h-[calc(100vh-1.5rem)] md:min-h-0 md:overflow-y-auto md:rounded-tl-xl lg:px-4"
->
-  <!-- <div class="flex flex-col gap-2 px-4 lg:px-16">
+<!-- <div class="flex flex-col gap-2 px-4 lg:px-16">
     <h2 class="font-montserrat text-xl font-semibold text-gray-800 lg:text-3xl">Groups</h2>
     <GroupCarousel />
   </div> -->
-  <div
-    class="flex flex-col gap-4 rounded-xl border-[1px] border-gray-300 bg-gradient-to-tr from-[rgba(55,124,251,0.05)] to-[rgba(246,128,103,0.05)] p-2 pt-4 lg:px-14"
-  >
-    <div class="flex w-full flex-col gap-2 pl-2">
-      <h2 class="font-montserrat text-xl font-semibold text-gray-800 lg:text-3xl">Meetings</h2>
-      <div class="flex lg:justify-start">
-        <div role="tablist" class="tabs tabs-bordered w-full lg:max-w-sm">
-          <button
-            role="tab"
-            class="tab font-montserrat font-medium text-gray-400 lg:text-lg"
-            class:tab-active={currentTab === 0}
-            class:text-gray-800={currentTab === 0}
-            style:border-color={currentTab === 0 ? "oklch(var(--a))" : undefined}
-            on:click={() => {
-              currentTab = 0;
-            }}>Scheduled</button
-          >
-          <button
-            role="tab"
-            class="tab font-montserrat font-medium text-gray-400 lg:text-lg"
-            class:tab-active={currentTab === 1}
-            class:text-gray-800={currentTab === 1}
-            style:border-color={currentTab === 1 ? "oklch(var(--a))" : undefined}
-            on:click={() => {
-              currentTab = 1;
-            }}>Unscheduled</button
-          >
-        </div>
-        <div class="hidden w-full border-b-2 border-gray-300 lg:block" />
+<div
+  class="mt-4 flex flex-col gap-4 rounded-xl border-[1px] border-gray-300 bg-gradient-to-tr from-[rgba(55,124,251,0.05)] to-[rgba(246,128,103,0.05)] p-2 pt-4 lg:px-14"
+>
+  <div class="flex w-full flex-col gap-2 pl-2">
+    <h2 class="font-montserrat text-xl font-semibold text-gray-800 lg:text-3xl">Meetings</h2>
+    <div class="flex lg:justify-start">
+      <div role="tablist" class="tabs tabs-bordered w-full lg:max-w-sm">
+        <button
+          role="tab"
+          class="tab font-montserrat font-medium text-gray-400 lg:text-lg"
+          class:tab-active={currentTab === 0}
+          class:text-gray-800={currentTab === 0}
+          style:border-color={currentTab === 0 ? "oklch(var(--a))" : undefined}
+          on:click={() => {
+            currentTab = 0;
+          }}>Scheduled</button
+        >
+        <button
+          role="tab"
+          class="tab font-montserrat font-medium text-gray-400 lg:text-lg"
+          class:tab-active={currentTab === 1}
+          class:text-gray-800={currentTab === 1}
+          style:border-color={currentTab === 1 ? "oklch(var(--a))" : undefined}
+          on:click={() => {
+            currentTab = 1;
+          }}>Unscheduled</button
+        >
       </div>
-    </div>
-
-    <div>
-      {#if currentTab === 0}
-        <ScheduledMeetingsList />
-      {:else if currentTab === 1}
-        <UnscheduledMeetingsList />
-      {/if}
+      <div class="hidden w-full border-b-2 border-gray-300 lg:block" />
     </div>
   </div>
-</main>
+
+  <div>
+    {#if currentTab === 0}
+      <ScheduledMeetingsList />
+    {:else if currentTab === 1}
+      <UnscheduledMeetingsList />
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Description
Remove functionality that is not planned for the first release, including status indicators, groups, and settings.

@seancfong feel free to commit on top if you want to tweak the styling of the page now that some elements are gone.

## Issues
- Closes #75 