### PR TITLE
feat: ✨ add ability to select dates in previous month

### DIFF
--- a/src/lib/components/creation/CalendarV2/CalendarBody.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBody.svelte
@@ -30,8 +30,7 @@
     }
   };
 
-  /**
-   * Creates the selectionupdateSelectedRange */
+  /* Confirms the current highlight selection and updates calendar accordingly */
   const handleEndSelection = (): void => {
     if (startDaySelection && endDaySelection) {
       try {
@@ -52,6 +51,11 @@
   {#each calendarDays as calendarWeek}
     <tr>
       {#each calendarWeek as calendarDay}
+        {@const isHighlighted =
+          startDaySelection &&
+          endDaySelection &&
+          calendarDay.determineDayWithinBounds(startDaySelection, endDaySelection)}
+        {@const isCurrentMonth = currentMonth === calendarDay.getMonth()}
         <td
           on:mouseup={() => {
             if (startDaySelection) {
@@ -60,47 +64,36 @@
             }
           }}
         >
-          {#if calendarDay.getMonth() === currentMonth}
-            {@const isHighlighted =
-              startDaySelection &&
-              endDaySelection &&
-              calendarDay.determineDayWithinBounds(startDaySelection, endDaySelection)}
-
-            <button
-              on:touchstart={(e) => {
-                if (e.cancelable) {
-                  e.preventDefault();
-                }
-                startDaySelection = calendarDay;
-              }}
-              on:mousedown={() => {
-                startDaySelection = calendarDay;
-              }}
-              on:touchmove={handleTouchMove}
-              on:mousemove={() => {
-                if (startDaySelection) {
-                  endDaySelection = calendarDay;
-                }
-              }}
-              on:touchend={(e) => {
-                if (e.cancelable) {
-                  e.preventDefault();
-                }
-                if (!endDaySelection) {
-                  endDaySelection = calendarDay;
-                }
-                handleEndSelection();
-              }}
-              tabindex="0"
-              class="relative flex w-full cursor-pointer select-none justify-center py-2"
-            >
-              <CalendarBodyDay {isHighlighted} {calendarDay} />
-            </button>
-          {:else}
-            <div class="flex w-full select-none justify-center py-2">
-              <p class="text-base text-gray-base md:text-xl">{calendarDay.getDay()}</p>
-            </div>
-          {/if}
+          <button
+            on:touchstart={(e) => {
+              if (e.cancelable) {
+                e.preventDefault();
+              }
+              startDaySelection = calendarDay;
+            }}
+            on:mousedown={() => {
+              startDaySelection = calendarDay;
+            }}
+            on:touchmove={handleTouchMove}
+            on:mousemove={() => {
+              if (startDaySelection) {
+                endDaySelection = calendarDay;
+              }
+            }}
+            on:touchend={(e) => {
+              if (e.cancelable) {
+                e.preventDefault();
+              }
+              if (!endDaySelection) {
+                endDaySelection = calendarDay;
+              }
+              handleEndSelection();
+            }}
+            tabindex="0"
+            class="relative flex w-full cursor-pointer select-none justify-center py-2"
+          >
+            <CalendarBodyDay {isHighlighted} {calendarDay} {isCurrentMonth} />
+          </button>
         </td>
       {/each}
     </tr>

--- a/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
@@ -1,28 +1,26 @@
 <script lang="ts">
   import type { ZotDate } from "$lib/utils/ZotDate";
+  import { cn } from "$lib/utils/utils";
 
   export let isHighlighted: boolean | null;
   export let calendarDay: ZotDate;
+  export let isCurrentMonth: boolean;
+
+  $: isSelected = calendarDay.isSelected;
 </script>
 
 <p
-  class="flex-center relative aspect-square h-8 w-8 text-base font-medium text-gray-dark md:h-12 md:w-12 md:text-xl"
-  class:day-selected={calendarDay.isSelected}
-  class:day-highlighted={isHighlighted}
+  class={cn(
+    "flex-center relative aspect-square h-8 w-8 rounded-lg text-base font-medium text-gray-dark md:h-12 md:w-12 md:rounded-xl md:text-xl",
+    isSelected && "bg-primary text-gray-light drop-shadow-[0_0px_16px_rgba(55,124,251,0.4)]",
+    isHighlighted && "bg-slate-base text-gray-dark drop-shadow-none",
+    !isCurrentMonth &&
+      cn("text-gray-base", isHighlighted && "bg-opacity-30", isSelected && "bg-opacity-50"),
+  )}
   data-day={calendarDay.getDay()}
   data-month={calendarDay.getMonth()}
   data-year={calendarDay.getYear()}
-  data-selected={calendarDay.isSelected}
+  data-selected={isSelected}
 >
   {calendarDay.getDay()}
 </p>
-
-<style lang="postcss">
-  .day-selected {
-    @apply rounded-lg bg-primary text-gray-light md:rounded-xl md:drop-shadow-[0_0px_16px_rgba(55,124,251,0.4)];
-  }
-
-  .day-highlighted {
-    @apply rounded-lg bg-slate-base text-gray-dark drop-shadow-none md:rounded-xl;
-  }
-</style>

--- a/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
+++ b/src/lib/components/creation/CalendarV2/CalendarBodyDay.svelte
@@ -12,10 +12,14 @@
 <p
   class={cn(
     "flex-center relative aspect-square h-8 w-8 rounded-lg text-base font-medium text-gray-dark md:h-12 md:w-12 md:rounded-xl md:text-xl",
-    isSelected && "bg-primary text-gray-light drop-shadow-[0_0px_16px_rgba(55,124,251,0.4)]",
-    isHighlighted && "bg-slate-base text-gray-dark drop-shadow-none",
+    isSelected && "bg-primary text-gray-50",
+    isHighlighted && "bg-slate-base text-gray-dark",
     !isCurrentMonth &&
-      cn("text-gray-base", isHighlighted && "bg-opacity-30", isSelected && "bg-opacity-50"),
+      cn(
+        "text-gray-base",
+        isHighlighted && "bg-opacity-30",
+        isSelected && "bg-opacity-50 text-gray-100",
+      ),
   )}
   data-day={calendarDay.getDay()}
   data-month={calendarDay.getMonth()}

--- a/src/lib/stores/meetingSetupStores.ts
+++ b/src/lib/stores/meetingSetupStores.ts
@@ -11,30 +11,14 @@ export const selectedDays = writable<ZotDate[]>([]);
  * @param endDate the day that the user ended the date multiselect range
  */
 export const updateSelectedRange = (startDate: ZotDate, endDate: ZotDate): void => {
-  if (startDate.getMonth() !== endDate.getMonth() || startDate.getYear() != endDate.getYear()) {
-    throw "The selected range must be in the same month.";
-  }
-
-  let lowerBound = startDate;
-  let upperBound = endDate;
-
-  // If the user selects backwards, swap the selections such that the date of lowerBound is before upperBound
-  if (startDate > endDate) {
-    lowerBound = endDate;
-    upperBound = startDate;
-  }
+  const highlightedRange: Date[] = ZotDate.generateRange(startDate.day, endDate.day);
 
   selectedDays.update((alreadySelectedDays: ZotDate[]) => {
     let modifiedSelectedDays = [...alreadySelectedDays];
 
-    const month = lowerBound.getMonth();
-    const year = lowerBound.getYear();
-
-    for (let day = lowerBound.getDay(); day <= upperBound.getDay(); day++) {
-      const dateToCheck = new Date(year, month, day);
-
+    highlightedRange.forEach((highlightedZotDate: Date) => {
       const foundSelectedDay = alreadySelectedDays.find(
-        (d) => d.isSelected && d.compareTo(new ZotDate(dateToCheck)) === 0,
+        (d) => d.compareTo(new ZotDate(highlightedZotDate)) === 0,
       );
 
       if (startDate.isSelected && foundSelectedDay) {
@@ -44,9 +28,9 @@ export const updateSelectedRange = (startDate: ZotDate, endDate: ZotDate): void 
         );
       } else if (!startDate.isSelected && !foundSelectedDay) {
         // Add day to selected days if the multiselect did not initiate from an already selected day
-        modifiedSelectedDays.push(new ZotDate(dateToCheck, true));
+        modifiedSelectedDays.push(new ZotDate(highlightedZotDate, true));
       }
-    }
+    });
 
     return modifiedSelectedDays;
   });

--- a/src/lib/utils/ZotDate.ts
+++ b/src/lib/utils/ZotDate.ts
@@ -83,6 +83,45 @@ export class ZotDate {
   }
 
   /**
+   * Given two Date bojects, generates a consecutive range of dates as an array of Date objects, regardless of their chronological order
+   * @param date1 a date representing a boundary of the date range
+   * @param date2 a date representing a boundary of the date range
+   * @returns an array of Dates representing the range of dates
+   */
+  static generateRange(date1: Date, date2: Date): Date[] {
+    if (date1 === date2) {
+      return [date1];
+    }
+
+    let earlierDate = date1;
+    let laterDate = date2;
+
+    if (date1 > date2) {
+      earlierDate = date2;
+      laterDate = date1;
+    }
+
+    const generatedRange: Date[] = [];
+
+    const maxRangeIterations =
+      CalendarConstants.MAX_DAYS_PER_WEEK * CalendarConstants.MAX_WEEKS_PER_MONTH;
+
+    const currentDate = earlierDate;
+
+    while (currentDate <= laterDate) {
+      if (generatedRange.length > maxRangeIterations) {
+        throw new Error(
+          `Maximum iterations for date selection range exceeded (${maxRangeIterations})`,
+        );
+      }
+
+      generatedRange.push(new Date(currentDate));
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+    return generatedRange;
+  }
+
+  /**
    * Given a zero-indexed month and a year, returns formatted days per week with appropriate padding
    * @param month zero-indexed month of the year
    * @param year number representing the year
@@ -298,5 +337,13 @@ export class ZotDate {
     for (let blockIndex = earlierBlockIndex; blockIndex <= laterBlockIndex; blockIndex++) {
       this.availability[blockIndex] = selection;
     }
+  }
+
+  /**
+   * Sets whether the day is selected or not
+   * @param isSelected a boolean representing whether the day is selected
+   */
+  setSelected(isSelected: boolean) {
+    this.isSelected = isSelected;
   }
 }

--- a/src/lib/utils/ZotDate.ts
+++ b/src/lib/utils/ZotDate.ts
@@ -112,15 +112,16 @@ export class ZotDate {
           nextMonthDay++;
         } else {
           newDate = new Date(year, month, day);
-          // Check if day is selected
-          if (
-            selectedDays &&
-            selectedDays.find((d: ZotDate) => d.compareTo(new ZotDate(newDate)) === 0)
-          ) {
-            isSelected = true;
-          }
 
           day++;
+        }
+
+        // Check if day is selected
+        if (
+          selectedDays &&
+          selectedDays.find((d: ZotDate) => d.compareTo(new ZotDate(newDate)) === 0)
+        ) {
+          isSelected = true;
         }
 
         const newZotDate = new ZotDate(newDate, isSelected);


### PR DESCRIPTION
## Summary

- Ability to select/deselect dates in previous and next months.
- Ability to select/deselect dates across months (even starting from previous month, ending on next month).
- Selected dates in other months will display as selected, just with lower opacity.
- Date selection union/difference behaviors also maintained across multiple months.

## Preview
![2024-03-31 00 30 56](https://github.com/icssc/ZotMeet/assets/37647466/203095b2-c7df-43b4-b82a-245ec425796b)
![2024-03-31 00 36 29](https://github.com/icssc/ZotMeet/assets/37647466/cc30be42-8bac-4583-9095-e8508315f089)

## Notes
- Tested on Chrome/Arc, Safari mobile

Closes #48 