### PR TITLE
Meeting Creation Functionality

### DIFF
--- a/src/lib/components/availability/GroupAvailability.svelte
+++ b/src/lib/components/availability/GroupAvailability.svelte
@@ -4,7 +4,7 @@
   import {
     availabilityDates,
     availabilityTimeBlocks,
-    groupMembers,
+    groupAvailabilities,
   } from "$lib/stores/availabilityStores";
   import { ZotDate } from "$lib/utils/ZotDate";
   import { cn } from "$lib/utils/utils";
@@ -47,10 +47,10 @@
         [];
 
       availableMembersOfSelection = availableMemberIndices.map(
-        (availableMemberIndex) => $groupMembers[availableMemberIndex].name,
+        (availableMemberIndex) => $groupAvailabilities[availableMemberIndex].name,
       );
 
-      notAvailableMembersOfSelection = $groupMembers
+      notAvailableMembersOfSelection = $groupAvailabilities
         .filter((_, index) => !availableMemberIndices.includes(index))
         .map((notAvailableMember) => notAvailableMember.name);
     }

--- a/src/lib/components/availability/GroupAvailabilityBlock.svelte
+++ b/src/lib/components/availability/GroupAvailabilityBlock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { groupMembers } from "$lib/stores/availabilityStores";
+  import { groupAvailabilities } from "$lib/stores/availabilityStores";
   import { cn } from "$lib/utils/utils";
 
   export let availableMemberIndices: number[] | null;
@@ -9,7 +9,7 @@
 
   const calculateGroupBlockColor = (availableMemberIndices: number[] | null): string => {
     if (availableMemberIndices) {
-      const opacity = availableMemberIndices.length / $groupMembers.length;
+      const opacity = availableMemberIndices.length / $groupAvailabilities.length;
       return `rgba(55, 124, 251, ${opacity})`;
     }
     return "transparent";

--- a/src/lib/components/creation/Creation.svelte
+++ b/src/lib/components/creation/Creation.svelte
@@ -1,11 +1,57 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import Calendar from "$lib/components/creation/CalendarV2/Calendar.svelte";
   import MeetingNameField from "$lib/components/creation/MeetingV2/MeetingNameField.svelte";
   import MeetingTimeField from "$lib/components/creation/MeetingV2/MeetingTimeField.svelte";
   import { selectedDays } from "$lib/stores/meetingSetupStores";
   import { startTime, endTime } from "$lib/stores/meetingSetupStores";
   import { meetingName } from "$lib/stores/meetingSetupStores";
+  import type { CreateMeetingPostParams } from "$lib/types/meetings";
   import { cn } from "$lib/utils/utils";
+
+  /**
+   * Converts a time string in the format "HH:MM" to an ISO string.
+   * @param time
+   */
+  function timeStringToIso(time: string): string {
+    const [hours, minutes] = time.split(":").map(Number);
+    const date = new Date();
+    date.setHours(hours);
+    date.setMinutes(minutes);
+    return date.toISOString();
+  }
+
+  const handleCreation = async () => {
+    const body: CreateMeetingPostParams = {
+      title: $meetingName,
+      fromTime: timeStringToIso($startTime),
+      toTime: timeStringToIso($endTime),
+      meetingDates: $selectedDays.map((zotDate) => zotDate.day.toISOString()),
+      description: "",
+    };
+
+    const response: Response = await fetch("/api/create", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error("Failed to create meeting: ", response.statusText);
+      return;
+    }
+
+    const { meetingId } = await response.json();
+
+    if (!meetingId) {
+      console.error("Failed to create meeting. Meeting ID not found.");
+      return;
+    }
+
+    goto(`/availability/${meetingId}`);
+  };
 </script>
 
 <div class="px-4 pt-8 md:pl-[60px] md:pt-10">
@@ -37,6 +83,7 @@
       "btn w-48 border-none bg-success font-montserrat text-xl font-medium text-gray-light sm:btn-wide",
     )}
     disabled={$selectedDays.length > 0 && $startTime && $endTime && $meetingName ? false : true}
+    on:click={handleCreation}
   >
     Continue →
   </button>

--- a/src/lib/components/creation/Creation.svelte
+++ b/src/lib/components/creation/Creation.svelte
@@ -9,23 +9,11 @@
   import type { CreateMeetingPostParams } from "$lib/types/meetings";
   import { cn } from "$lib/utils/utils";
 
-  /**
-   * Converts a time string in the format "HH:MM" to an ISO string.
-   * @param time
-   */
-  function timeStringToIso(time: string): string {
-    const [hours, minutes] = time.split(":").map(Number);
-    const date = new Date();
-    date.setHours(hours);
-    date.setMinutes(minutes);
-    return date.toISOString();
-  }
-
   const handleCreation = async () => {
     const body: CreateMeetingPostParams = {
       title: $meetingName,
-      fromTime: timeStringToIso($startTime),
-      toTime: timeStringToIso($endTime),
+      fromTime: $startTime,
+      toTime: $endTime,
       meetingDates: $selectedDays.map((zotDate) => zotDate.day.toISOString()),
       description: "",
     };

--- a/src/lib/db/databaseUtils.server.ts
+++ b/src/lib/db/databaseUtils.server.ts
@@ -99,21 +99,15 @@ export const getExistingGuest = async (username: string, meeting: MeetingSelectS
 };
 
 /**
- * To create a meeting, call this function with:
- * 1. A title
- * 2. A start time; I used: 2024-01-31T16:00:00.000Z
- * 3. An end time: I used: 2024-02-06T16:00:00.000Z
- *
- * NOTE:
- * `generateSampleDates()` is called whenever no availability is found
- * If you use dates other than the ones above, generateSampleDates() will return dates
- * other than the ones your meeting may *actually* be of
- *
- * @param meeting
+ * @param meeting The meeting object to insert. `from_time` and `to_time` represent the start and end times
+ * and are only used for the times of day.
+ * @param meetingDates The dates to insert for the meeting. Only the date portion of the date object is used.
+ * @returns The id of the inserted meeting.
  */
-export const insertMeeting = async (meeting: MeetingInsertSchema) => {
+export const insertMeeting = async (meeting: MeetingInsertSchema, meetingDates: Date[]) => {
   const [dbMeeting] = await db.insert(meetings).values(meeting).returning();
-  await insertMeetingDates(dbMeeting);
+  await insertMeetingDates(meetingDates, dbMeeting.id);
+  return dbMeeting.id;
 };
 
 export const getExistingMeeting = async (meetingId: string) => {
@@ -122,16 +116,14 @@ export const getExistingMeeting = async (meetingId: string) => {
   return dbMeeting;
 };
 
-export const insertMeetingDates = async (meeting: MeetingSelectSchema) => {
-  const currentDate = meeting.from_time;
-  currentDate.setDate(currentDate.getDate());
+export const insertMeetingDates = async (dates: Date[], meeting_id: string) => {
+  const dbMeetingDates: MeetingDateInsertSchema[] = dates.map((date) => {
+    // Get the start of the date to better standardize
+    const startOfDay = new Date(date.toDateString());
+    return { meeting_id, date: startOfDay };
+  });
 
-  for (let i = 0; currentDate <= meeting.to_time; i++) {
-    const value: MeetingDateInsertSchema = { date: currentDate, meeting_id: meeting.id };
-    await db.insert(meetingDates).values(value);
-
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
+  await db.insert(meetingDates).values(dbMeetingDates);
 };
 
 export const getExistingMeetingDates = async (meetingId: string) => {

--- a/src/lib/db/databaseUtils.server.ts
+++ b/src/lib/db/databaseUtils.server.ts
@@ -3,7 +3,7 @@ import type { SuperValidated } from "sveltekit-superforms";
 import type { ZodObject, ZodString } from "zod";
 
 import { db } from "./drizzle";
-import { members, users, guests, meetings, meetingDates } from "./schema";
+import { members, users, guests, meetings, meetingDates, sessions } from "./schema";
 import type {
   UserInsertSchema,
   MemberInsertSchema,
@@ -88,6 +88,15 @@ export const getExistingUser = async (
 
   return existingUser;
 };
+
+export async function getUserIdFromSession(sessionId: string): Promise<string> {
+  const [{ userId }] = await db
+    .select({ userId: sessions.userId })
+    .from(sessions)
+    .where(eq(sessions.id, sessionId));
+
+  return userId;
+}
 
 export const getExistingGuest = async (username: string, meeting: MeetingSelectSchema) => {
   const [existingGuest] = await db

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -11,6 +11,7 @@ import {
   boolean,
   json,
   pgTable,
+  char,
 } from "drizzle-orm/pg-core";
 
 export const attendanceEnum = pgEnum("attendance", ["accepted", "maybe", "declined"]);
@@ -54,8 +55,8 @@ export const meetings = pgTable("meetings", {
   description: text("description"),
   location: text("location"),
   scheduled: boolean("scheduled"),
-  from_time: timestamp("from_time").notNull(),
-  to_time: timestamp("to_time").notNull(),
+  from_time: char("from_time", { length: 5 }).notNull(),
+  to_time: char("to_time", { length: 5 }).notNull(),
   group_id: uuid("group_id").references(() => groups.id, { onDelete: "cascade" }),
   host_id: text("host_id").references(() => members.id),
 });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -14,7 +14,10 @@ import {
   char,
 } from "drizzle-orm/pg-core";
 
-export const attendanceEnum = pgEnum("attendance", ["accepted", "maybe", "declined"]);
+export const attendanceValues = ["accepted", "maybe", "declined"] as const;
+export type AttendanceValue = (typeof attendanceValues)[number];
+
+export const attendanceEnum = pgEnum("attendance", attendanceValues);
 export const memberEnum = pgEnum("member_type", ["guest", "user"]);
 
 // Members encompasses anyone who uses ZotMeet, regardless of guest or user status.

--- a/src/lib/stores/availabilityStores.ts
+++ b/src/lib/stores/availabilityStores.ts
@@ -93,7 +93,7 @@ export const availabilityDates = writable<ZotDate[]>(
   generateSampleDates(earliestTime, latestTime, sampleMembers),
 );
 export const availabilityTimeBlocks = writable<number[]>(defaultTimeBlocks);
-export const groupMembers = readable<MemberAvailability[]>(sampleMembers);
+export const groupAvailabilities = readable<MemberAvailability[]>(sampleMembers);
 
 export const isEditingAvailability = writable<boolean>(false);
 export const isStateUnsaved = writable<boolean>(false);

--- a/src/lib/stores/meetingSetupStores.ts
+++ b/src/lib/stores/meetingSetupStores.ts
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 
+import type { HourMinuteString } from "$lib/types/chrono";
 import type { MeetingTime } from "$lib/types/meetings";
 import { ZotDate } from "$lib/utils/ZotDate";
 
@@ -40,9 +41,9 @@ export const DEFAULT_MEETING_NAME = "";
 export const meetingName = writable<string>(DEFAULT_MEETING_NAME);
 
 export const DEFAULT_MEETING_TIMES: MeetingTime = {
-  startTime: "08:00",
-  endTime: "17:00",
+  startTime: "09:00",
+  endTime: "16:00",
 };
 
-export const startTime = writable<string>(DEFAULT_MEETING_TIMES.startTime);
-export const endTime = writable<string>(DEFAULT_MEETING_TIMES.endTime);
+export const startTime = writable<HourMinuteString>(DEFAULT_MEETING_TIMES.startTime);
+export const endTime = writable<HourMinuteString>(DEFAULT_MEETING_TIMES.endTime);

--- a/src/lib/types/chrono.ts
+++ b/src/lib/types/chrono.ts
@@ -35,3 +35,5 @@ export enum CalendarConstants {
 export enum TimeConstants {
   MINUTES_PER_HOUR = 60,
 }
+
+export type HourMinuteString = `${string}:${string}`;

--- a/src/lib/types/meetings.ts
+++ b/src/lib/types/meetings.ts
@@ -31,3 +31,12 @@ export type MeetingTime = {
   startTime: string;
   endTime: string;
 };
+
+/** All time strings are ISO */
+export interface CreateMeetingPostParams {
+  title: string;
+  description: string;
+  fromTime: string;
+  toTime: string;
+  meetingDates: string[];
+}

--- a/src/lib/types/meetings.ts
+++ b/src/lib/types/meetings.ts
@@ -40,4 +40,5 @@ export interface CreateMeetingPostParams {
   fromTime: HourMinuteString;
   toTime: HourMinuteString;
   meetingDates: string[]; // ISO date strings
+  sessionId?: string;
 }

--- a/src/lib/types/meetings.ts
+++ b/src/lib/types/meetings.ts
@@ -1,3 +1,5 @@
+import type { HourMinuteString } from "./chrono";
+
 export type Group = { name: string; id: number; img: string; link: string };
 
 export type Meeting = ScheduledMeeting | UnscheduledMeeting;
@@ -28,15 +30,14 @@ export type UnscheduledMeeting = {
 };
 
 export type MeetingTime = {
-  startTime: string;
-  endTime: string;
+  startTime: HourMinuteString;
+  endTime: HourMinuteString;
 };
 
-/** All time strings are ISO */
 export interface CreateMeetingPostParams {
   title: string;
   description: string;
-  fromTime: string;
-  toTime: string;
-  meetingDates: string[];
+  fromTime: HourMinuteString;
+  toTime: HourMinuteString;
+  meetingDates: string[]; // ISO date strings
 }

--- a/src/routes/api/create/+server.ts
+++ b/src/routes/api/create/+server.ts
@@ -2,7 +2,6 @@ import { error, json } from "@sveltejs/kit";
 
 import { insertMeeting } from "$lib/db/databaseUtils.server";
 import type { MeetingInsertSchema } from "$lib/db/schema";
-import type { HourMinuteString } from "$lib/types/chrono.js";
 import type { CreateMeetingPostParams } from "$lib/types/meetings";
 
 export async function POST({ request }) {
@@ -28,14 +27,11 @@ export async function POST({ request }) {
     .map((dateString) => new Date(dateString))
     .sort((a, b) => a.getUTCMilliseconds() - b.getUTCMilliseconds());
 
-  const firstDate = sortedDates[0];
-  const lastDate = sortedDates[sortedDates.length - 1];
-
   const meeting: MeetingInsertSchema = {
     title,
     description: description || "",
-    from_time: dateWithHourMinute(firstDate, fromTime),
-    to_time: dateWithHourMinute(lastDate, toTime),
+    from_time: fromTime,
+    to_time: toTime,
   };
 
   try {
@@ -45,11 +41,4 @@ export async function POST({ request }) {
     console.log("Error creating meeting:", err);
     error(500, "Error creating meeting");
   }
-}
-
-function dateWithHourMinute(date: Date, time: HourMinuteString) {
-  const [hour, minute] = time.split(":").map((t) => parseInt(t, 10));
-  const newDate = new Date(date);
-  date.setHours(hour, minute, 0, 0);
-  return newDate;
 }

--- a/src/routes/api/create/+server.ts
+++ b/src/routes/api/create/+server.ts
@@ -1,11 +1,11 @@
 import { error, json } from "@sveltejs/kit";
 
-import { insertMeeting } from "$lib/db/databaseUtils.server";
+import { getUserIdFromSession, insertMeeting } from "$lib/db/databaseUtils.server";
 import type { MeetingInsertSchema } from "$lib/db/schema";
 import type { CreateMeetingPostParams } from "$lib/types/meetings";
 
 export async function POST({ request }) {
-  const { title, description, fromTime, toTime, meetingDates }: CreateMeetingPostParams =
+  const { title, description, fromTime, toTime, meetingDates, sessionId }: CreateMeetingPostParams =
     await request.json();
 
   console.log("Creating meeting:", title, description, fromTime, toTime, meetingDates);
@@ -27,11 +27,14 @@ export async function POST({ request }) {
     .map((dateString) => new Date(dateString))
     .sort((a, b) => a.getUTCMilliseconds() - b.getUTCMilliseconds());
 
+  const host_id = sessionId ? await getUserIdFromSession(sessionId) : undefined;
+
   const meeting: MeetingInsertSchema = {
     title,
     description: description || "",
     from_time: fromTime,
     to_time: toTime,
+    host_id,
   };
 
   try {

--- a/src/routes/api/create/+server.ts
+++ b/src/routes/api/create/+server.ts
@@ -1,0 +1,44 @@
+import { error, json } from "@sveltejs/kit";
+
+import { insertMeeting } from "$lib/db/databaseUtils.server";
+import type { MeetingInsertSchema } from "$lib/db/schema";
+import type { CreateMeetingPostParams } from "$lib/types/meetings";
+
+export async function POST({ request }) {
+  const { title, description, fromTime, toTime, meetingDates }: CreateMeetingPostParams =
+    await request.json();
+
+  console.log("Creating meeting:", title, description, fromTime, toTime, meetingDates);
+
+  if (fromTime >= toTime) {
+    error(400, "From time must be before to time");
+  }
+
+  if (meetingDates.length === 0) {
+    error(400, "At least one date must be provided");
+  }
+
+  // Just so we don't get flooded too easily
+  if (meetingDates.length > 100) {
+    error(400, "Too many dates provided");
+  }
+
+  const sortedDates = meetingDates
+    .map((dateString) => new Date(dateString))
+    .sort((a, b) => a.getUTCMilliseconds() - b.getUTCMilliseconds());
+
+  const meeting: MeetingInsertSchema = {
+    title,
+    description: description || "",
+    from_time: new Date(fromTime),
+    to_time: new Date(toTime),
+  };
+
+  try {
+    const meetingId = await insertMeeting(meeting, sortedDates);
+    return json({ meetingId });
+  } catch (err) {
+    console.log("Error creating meeting:", err);
+    error(500, "Error creating meeting");
+  }
+}

--- a/src/routes/auth/guest/+page.server.ts
+++ b/src/routes/auth/guest/+page.server.ts
@@ -2,11 +2,10 @@ import { fail } from "@sveltejs/kit";
 import { generateId } from "lucia";
 import { setError, superValidate } from "sveltekit-superforms/client";
 
-import { _getMeeting } from "../../availability/[slug]/+page.server";
-
 import { guestSchema } from "$lib/config/zod-schemas";
 import {
   checkIfGuestUsernameExists,
+  getExistingMeeting,
   // insertMeeting,
   insertNewGuest,
   insertNewMember,
@@ -32,7 +31,7 @@ async function createGuest({ request }: { request: Request }) {
   try {
     const isGuestUsernameAlreadyRegistered = await checkIfGuestUsernameExists(
       form.data.username,
-      await _getMeeting(form.data.meetingId),
+      await getExistingMeeting(form.data.meetingId),
     );
 
     if (isGuestUsernameAlreadyRegistered === true) {


### PR DESCRIPTION
## Description
- Add functionality to create meeting according to data in the meeting setup stores.
- The page redirects based on the id of the created meeting and does not redirect if a meeting ID is not received.
- Refactor `insertMeeting` and `insertMeetingDates` to accept a list of dates (instead of a range provided by start and end times).
- Change the start and end times to `HourMinuteString` (HH:MM) from timestamp.
    - There was no reason to use ISO time stamp there. This just makes it clear. It doesn't work with time zones, but our app wouldn't work properly in different time zones anyway.

## Test Plan
- Input requisite data in the meeting creation page.
- Click create and see that it redirects to the availability page.
- Verify that the dates in the availability page match up with the ones selected in the creation page.
    - NOTE: The time range won't match up because it's hard-coded to be 8-5:30.
- Verify that the start and end times are correct in the database.

## Issues
- Closes #50 

## Future Follow-Up
- Display the availability time range according to the start and end times of the meeting in the database (#103).
- Verify that everything works between time zones or lock everything to one time zone.
    - I'm of the opinion that the latter is preferred.
- Add meeting name to availability page.