### PR TITLE
feat: ✨ fix cancel for non-members

### DIFF
--- a/src/routes/availability/[slug]/+page.svelte
+++ b/src/routes/availability/[slug]/+page.svelte
@@ -8,7 +8,6 @@
   import {
     availabilityDates,
     availabilityTimeBlocks,
-    generateSampleDates,
     generateTimeBlocks,
     getTimeFromHourMinuteString,
     guestSession,
@@ -17,6 +16,7 @@
   } from "$lib/stores/availabilityStores";
   import { endTime, startTime } from "$lib/stores/meetingSetupStores";
   import type { HourMinuteString } from "$lib/types/chrono";
+  import { ZotDate } from "$lib/utils/ZotDate";
   import { getGeneralAvailability } from "$lib/utils/availability";
   import { cn } from "$lib/utils/utils";
   import CancelCircleOutline from "~icons/mdi/cancel-circle-outline";
@@ -44,8 +44,21 @@
   };
 
   const handleCancel = async () => {
-    $availabilityDates =
-      (await getGeneralAvailability(data, $guestSession)) ?? generateSampleDates();
+    const generalAvailability = await getGeneralAvailability(data, $guestSession);
+
+    if (!generalAvailability || generalAvailability.length === 0) {
+      const updatedAvailabilityDates = $availabilityDates.map((item) => {
+        return new ZotDate(
+          item.day,
+          item.isSelected,
+          item.availability.map(() => false),
+        );
+      });
+
+      availabilityDates.set(updatedAvailabilityDates);
+    } else {
+      $availabilityDates = generalAvailability;
+    }
 
     $isEditingAvailability = !$isEditingAvailability;
     $isStateUnsaved = false;


### PR DESCRIPTION
## Summary
1. Correctly clears availability, rather than replacing it with incorrect testing data, when a non-member (no account, no guest) cancels their current selection

![chrome-capture-2024-5-3 (1)](https://github.com/icssc/ZotMeet/assets/100006999/568a1089-55d9-46e1-a402-d703f8df335a)

Closes #113
