### PR TITLE
173 add ability to edit delete meetings

### DIFF
--- a/src/components/availability/availability-header.tsx
+++ b/src/components/availability/availability-header.tsx
@@ -58,7 +58,6 @@ export function AvailabilityHeader({
         timezone: string;
         meetingDates: string[];
     }) => {
-        console.log("Editing meeting:", meeting);
         const newMeeting = {
             title: meeting.title,
             description: meeting.description,
@@ -77,11 +76,8 @@ export function AvailabilityHeader({
             console.error("Failed to create meeting: ", error);
         }
 
-        console.log("Editing meeting...");
-
         setSaved(true);
         setIsModalOpen(false); // Close modal after saving
-        console.log("Data saved!");
     };
 
     const handleCancel = () => {

--- a/src/components/edit/edit-modal.tsx
+++ b/src/components/edit/edit-modal.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { HourMinuteString } from "@/lib/types/chrono";
+import { ZotDate } from "@/lib/zotdate";
+
+import { Calendar } from "../creation/calendar/calendar";
+import { MeetingNameField } from "../creation/fields/meeting-name-field";
+import { MeetingTimeField } from "../creation/fields/meeting-time-field";
+
+type ModalProps = {
+    isOpen: boolean;
+    onClose: (meeting: any) => void;
+    onSave: (meeting: {
+        title: string;
+        description: string;
+        fromTime: HourMinuteString;
+        toTime: HourMinuteString;
+        timezone: string;
+        meetingDates: string[];
+    }) => void;
+    children: React.ReactNode;
+};
+
+const EditingModal: React.FC<ModalProps> = ({ isOpen, onClose, onSave }) => {
+    if (!isOpen) return null;
+    const [selectedDays, setSelectedDays] = useState<ZotDate[]>([]);
+
+    const [startTime, setStartTime] = useState<HourMinuteString>("09:00:00");
+    const [endTime, setEndTime] = useState<HourMinuteString>("13:00:00");
+    const [meetingName, setMeetingName] = useState("");
+
+    const handleEditClick = async () => {
+        const newName = meetingName;
+        const newStartTime = startTime as HourMinuteString;
+        const newEndTime = endTime as HourMinuteString;
+
+        const newMeetingDates = selectedDays;
+
+        // You can add actual logic here, e.g. API call or state update
+        const newMeeting = {
+            title: newName,
+            description: "",
+            fromTime: newStartTime,
+            toTime: newEndTime,
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            meetingDates: newMeetingDates.map((zotDate) =>
+                zotDate.day.toISOString()
+            ),
+        };
+
+        onSave(newMeeting);
+    };
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="relative w-full max-w-lg rounded bg-white p-6 shadow-lg md:max-w-2xl lg:max-w-4xl">
+                <div className="relative max-h-[60vh] w-full overflow-y-auto rounded-xl border bg-white px-8 py-6 md:px-14">
+                    <div className="flex flex-col gap-6">
+                        <h2 className="font-bold-montserrat mb-4 text-xl">
+                            Edit Meeting
+                        </h2>
+                        <MeetingNameField
+                            meetingName={meetingName}
+                            setMeetingName={setMeetingName}
+                        />
+
+                        <MeetingTimeField
+                            setStartTime={setStartTime}
+                            setEndTime={setEndTime}
+                        />
+
+                        <Calendar
+                            selectedDays={selectedDays}
+                            setSelectedDays={setSelectedDays}
+                        />
+                    </div>
+                </div>
+                <button
+                    onClick={onClose}
+                    className="absolute right-2 top-2 text-gray-500 hover:text-black"
+                >
+                    &times;
+                </button>
+                <div className="flex justify-end gap-2">
+                    <button
+                        onClick={onClose}
+                        className="mt-4 rounded bg-red-600 px-4 py-2 text-white transition hover:bg-red-700"
+                    >
+                        Close
+                    </button>
+                    <button
+                        onClick={handleEditClick}
+                        className="mt-4 justify-end rounded bg-green-600 px-4 py-2 text-white transition hover:bg-green-700"
+                    >
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default EditingModal;

--- a/src/db/migrations/0002_panoramic_frog_thor.sql
+++ b/src/db/migrations/0002_panoramic_frog_thor.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "meetings" ADD COLUMN "archived" boolean DEFAULT false;

--- a/src/db/migrations/meta/0002_snapshot.json
+++ b/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,531 @@
+{
+  "id": "b96ce79c-3001-4db2-9998-ff83c80de3a7",
+  "prevId": "313b7620-6042-45c1-b3ba-ab5f75b1c3fa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availabilities": {
+      "name": "availabilities",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_availabilities": {
+          "name": "meeting_availabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "availabilities_member_id_members_id_fk": {
+          "name": "availabilities_member_id_members_id_fk",
+          "tableFrom": "availabilities",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availabilities_meeting_id_meetings_id_fk": {
+          "name": "availabilities_meeting_id_meetings_id_fk",
+          "tableFrom": "availabilities",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "availabilities_member_id_meeting_id_pk": {
+          "name": "availabilities_member_id_meeting_id_pk",
+          "columns": [
+            "member_id",
+            "meeting_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_user_id_users_id_fk": {
+          "name": "groups_user_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled": {
+          "name": "scheduled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_time": {
+          "name": "from_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_time": {
+          "name": "to_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dates": {
+          "name": "dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meetings_group_id_groups_id_fk": {
+          "name": "meetings_group_id_groups_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_host_id_members_id_fk": {
+          "name": "meetings_host_id_members_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "members",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_accounts_provider_id_provider_user_id_pk": {
+          "name": "oauth_accounts_provider_id_provider_user_id_pk",
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_idx_sessions": {
+          "name": "user_idx_sessions",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_member_id_members_id_fk": {
+          "name": "users_member_id_members_id_fk",
+          "tableFrom": "users",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.users_in_group": {
+      "name": "users_in_group",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_in_group_user_id_users_id_fk": {
+          "name": "users_in_group_user_id_users_id_fk",
+          "tableFrom": "users_in_group",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_in_group_group_id_groups_id_fk": {
+          "name": "users_in_group_group_id_groups_id_fk",
+          "tableFrom": "users_in_group",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_in_group_group_id_user_id_pk": {
+          "name": "users_in_group_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.attendance": {
+      "name": "attendance",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "maybe",
+        "declined"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1746913110348,
       "tag": "0001_lyrical_blacklash",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1747196719947,
+      "tag": "0002_panoramic_frog_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -143,6 +143,7 @@ export const meetings = pgTable("meetings", {
     // JSON array of calendar dates
     dates: jsonb("dates").$type<string[]>().notNull().default([]),
     createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    archived: boolean("archived").default(false),
 });
 
 export const meetingsRelations = relations(meetings, ({ one, many }) => ({

--- a/src/server/actions/meeting/delete/action.ts
+++ b/src/server/actions/meeting/delete/action.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { db } from "@/db";
+import { meetings } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getCurrentSession } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export async function deleteMeeting(id: string) {
+    const meetingId = id;
+    console.log("IN DELETE MEETING ACTION");
+    console.log("meeting id:", meetingId);
+
+    const { user } = await getCurrentSession();
+
+    if (!user) {
+        return { error: "You must be logged in to delete a meeting." };
+    }
+
+    await db.update(meetings)
+    .set({archived: true})
+    .where(eq(meetings.id, meetingId));
+
+    redirect("/summary");
+
+}

--- a/src/server/actions/meeting/delete/action.ts
+++ b/src/server/actions/meeting/delete/action.ts
@@ -8,8 +8,6 @@ import { redirect } from "next/navigation";
 
 export async function deleteMeeting(id: string) {
     const meetingId = id;
-    console.log("IN DELETE MEETING ACTION");
-    console.log("meeting id:", meetingId);
 
     const { user } = await getCurrentSession();
 

--- a/src/server/actions/meeting/edit/action.ts
+++ b/src/server/actions/meeting/edit/action.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { db } from "@/db";
+import { meetings } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getCurrentSession } from "@/lib/auth";
+import { CreateMeetingPostParams } from "@/lib/types/meetings";
+
+export async function editMeeting(id: string, meetingData: CreateMeetingPostParams) {
+    const meetingId = id;
+
+    const { title, description, fromTime, toTime, timezone, meetingDates } =
+        meetingData; //description and timezone could be edited in the future
+
+    const { user } = await getCurrentSession();
+
+    if (!user) {
+        return { error: "You must be logged in to edit a meeting." };
+    }
+
+    if (
+        fromTime >= toTime ||
+        new Set(meetingDates).size !== meetingDates.length
+    ) {
+        return { error: "Invalid meeting dates or times." };
+    }
+    await db.update(meetings)
+    .set({fromTime: fromTime, toTime: toTime})
+    .where(eq(meetings.id, meetingId));
+
+    if (title !== "") {
+        await db.update(meetings)
+        .set({title: title})
+        .where(eq(meetings.id, meetingId));
+    }
+    if (meetingDates.length > 0) {
+        await db.update(meetings)
+        .set({dates: meetingDates})
+        .where(eq(meetings.id, meetingId));
+    }
+
+    
+
+    return {
+        status: 200,
+        body: {
+            message: "Saved successfully",
+        },
+    };    
+
+}

--- a/src/server/data/meeting/queries.ts
+++ b/src/server/data/meeting/queries.ts
@@ -14,7 +14,7 @@ export async function getExistingMeeting(
     meetingId: string
 ): Promise<SelectMeeting> {
     const meeting = await db.query.meetings.findFirst({
-        where: eq(meetings.id, meetingId),
+        where: and(eq(meetings.id, meetingId), eq(meetings.archived, false)),
     });
 
     if (!meeting) {


### PR DESCRIPTION
### Currently implemented:
- Functioning button that edits meeting data
  -  can edit the name, times, and dates separately
- Added archive column to the `meeting` table
- Functioning button that deletes a meeting ("archives" it, then leads back to the summary page)

### Next steps:
- I couldn't figure out how to make the font size of edit and delete to be the same as the `Add Availability` button 🥲
- New Bugs
  - There is an issue with saving availabilities, where availabilities that are added after the first save do not appear on the table when the meeting's time/date changes. However, the original availabilities are preserved as expected.
   - The `summary` page does not filter for non-archived meetings, because it isn't using the `getExistingMeetings` function, (believe it is just getting all meetings) so that should be changed.