### PR TITLE
fix: 🐛 resolve issue with multiple meetings being created (#182)

### DIFF
--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -15,8 +15,12 @@ export function Creation() {
     const [startTime, setStartTime] = useState<HourMinuteString>("09:00:00");
     const [endTime, setEndTime] = useState<HourMinuteString>("13:00:00");
     const [meetingName, setMeetingName] = useState("");
+    const [isCreating, setIsCreating] = useState(false);
 
     const handleCreation = async () => {
+        if (isCreating) return;
+        setIsCreating(true);
+    
         const newMeeting = {
             title: meetingName,
             fromTime: startTime,
@@ -29,10 +33,10 @@ export function Creation() {
         };
 
         const result = await createMeeting(newMeeting);
-        const error = result?.error;
-
-        if (error) {
-            console.error("Failed to create meeting: ", error);
+        
+        if (result?.error) {
+            console.error("Failed to create meeting: ", result.error);
+            setIsCreating(false);
         }
     };
 
@@ -86,10 +90,10 @@ export function Creation() {
                     className={cn(
                         "sm:btn-wide w-48 rounded-lg border-none bg-green-500 font-montserrat text-xl font-medium text-gray-light hover:bg-green-500/80"
                     )}
-                    disabled={!hasValidInputs}
+                    disabled={!hasValidInputs || isCreating}
                     onClick={handleCreation}
                 >
-                    Continue →
+                    {isCreating ? "Creating..." : "Continue →"}
                 </Button>
             </div>
         </div>


### PR DESCRIPTION
## Summary

This PR fixes issue #182 where meetings were being created multiple times.

## Fix

- Introduced an `isCreating` flag to prevent multiple meeting submissions.
- Disabled the "Continue" button and changed its label to "Creating..." while the meeting is being processed to prevent repeated clicks


## Related Issue

Closes #182
