### PR TITLE
fix: 🐛 seeing if this fixes hovering

### DIFF
--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -38,7 +38,7 @@ export function GroupResponses({
         }
 
         const member = members.find((m) => m.memberId === memberId);
-        setHoveredMember(member ? member.displayName : null);
+        setHoveredMember(member ? member.memberId : null);
     };
 
     const { availableMembers, notAvailableMembers } = useMemo(() => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    extends
+        React.ButtonHTMLAttributes<HTMLButtonElement>,
         VariantProps<typeof buttonVariants> {
     asChild?: boolean;
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -47,7 +47,8 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-    extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    extends
+        React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
         VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<


### PR DESCRIPTION
Hovering over member names and seeing their personal availability works! Credits to the edit suggestor, Caden Lee who thought of this feature fix. 
It only whens when a time cell is already selected though (otherwise nothing happens), so not sure if we want to do anything about that.

Video demo:
https://github.com/user-attachments/assets/1208dba1-970d-4cdf-939e-2db6eeca1e01

