### PR TITLE
fix: 🐛 absolute favicon path so that request doesn't go to /availabilities

### DIFF
--- a/src/app/availability/[slug]/page.tsx
+++ b/src/app/availability/[slug]/page.tsx
@@ -15,7 +15,6 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps) {
     const { slug } = params;
-    console.log("Generating metadata for meeting slug:", slug);
 
     const meetingData = await getExistingMeeting(slug).catch((e) => {
         if (e instanceof Error) {


### PR DESCRIPTION
## Problem
`favicon.ico` was getting passed as the slug to `/availabilities` when rendering a single meeting (I could only reproduce this issue once)
## Solution
Created an absolute path to `favicon.ico` from the `layout.tsx` file by changing the icon path to `/favicon.ico`. 
The [NextJS documentation](https://nextjs.org/docs/15/app/api-reference/file-conventions/metadata/app-icons#favicon) shows the icon's path preceeded by a `/` in the static metadata object.
### Other potential fixes
1. Moving the favicon to the `/public` folder (fix suggested by Github Copilot)
    I didn't go with this fix since the [NextJS favicon documentation](https://nextjs.org/docs/15/app/api-reference/file-conventions/metadata/app-icons#image-files-ico-jpg-png) clearly states that the favicon should be in the `/app` folder (`/src/app` in our case).
    However, the [documentation](https://nextjs.org/docs/15/pages/api-reference/file-conventions/public-folder#robots-favicons-and-others) for the `/public` folder does mention that the favicon could be stored there 
2. Removing the `icons` field from the `metadata` object in `layout.tsx`