### PR TITLE
feat: Improve pagination by adding jagged edges and encircling arrows across entire UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,108 @@ body {
 	.flex-between {
 		@apply flex items-center justify-between;
 	}
+
+	/* Container needs overflow hidden to clip content */
+	.jagged-table-container {
+		overflow: hidden;
+		background: #fafafa;
+		isolation: isolate;
+	}
+
+	/* Ensure table doesn't overflow the masked area */
+	.jagged-table-container table {
+		isolation: isolate;
+	}
+
+	/* Apply jagged masking to tbody - preserves time column */
+	tbody.calendar-jagged-right {
+		mask-image: url(#jagged-mask-right);
+		-webkit-mask-image: url(#jagged-mask-right);
+		mask-size: 100% 100%;
+		-webkit-mask-size: 100% 100%;
+		mask-composite: source-in;
+		-webkit-mask-composite: source-in;
+	}
+
+	tbody.calendar-jagged-left {
+		mask-image: url(#jagged-mask-left);
+		-webkit-mask-image: url(#jagged-mask-left);
+		mask-size: 100% 100%;
+		-webkit-mask-size: 100% 100%;
+		mask-composite: source-in;
+		-webkit-mask-composite: source-in;
+	}
+
+	tbody.calendar-jagged-both {
+		mask-image: url(#jagged-mask-both);
+		-webkit-mask-image: url(#jagged-mask-both);
+		mask-size: 100% 100%;
+		-webkit-mask-size: 100% 100%;
+		mask-composite: source-in;
+		-webkit-mask-composite: source-in;
+	}
+
+	/* Hide content that extends beyond the masked area */
+	tbody.calendar-jagged-right tr,
+	tbody.calendar-jagged-left tr,
+	tbody.calendar-jagged-both tr {
+		isolation: isolate;
+	}
+
+	/* Hide borders on data cells to prevent them showing through mask */
+	tbody.calendar-jagged-left td:nth-child(2),
+	tbody.calendar-jagged-both td:nth-child(2) {
+		border-left: none;
+	}
+
+	/* Hide the time column's right border when left edge is jagged */
+	tbody.calendar-jagged-left td:first-child,
+	tbody.calendar-jagged-both td:first-child {
+		border-right: none;
+	}
+
+	/* Ensure all cell borders in masked area are hidden */
+	tbody.calendar-jagged-left td,
+	tbody.calendar-jagged-both td,
+	tbody.calendar-jagged-right td {
+		box-shadow: none;
+	}
+
+	/* Allow time column content to overflow without clipping */
+	tbody.calendar-jagged-left td:first-child,
+	tbody.calendar-jagged-both td:first-child,
+	tbody.calendar-jagged-right td:first-child {
+		overflow: visible;
+		min-width: max-content;
+	}
+
+	/* Outline SVG overlay */
+	.calendar-jagged-outline {
+		position: absolute;
+		left: 0;
+		right: 0;
+		width: 100%;
+		pointer-events: none;
+		overflow: visible;
+		z-index: 10;
+	}
+
+	/* Position overlay to match tbody */
+	.relative table + .calendar-jagged-outline {
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+
+	path#jagged-right-stroke {
+		stroke: currentcolor;
+		stroke-width: 0.5px;
+	}
+
+	path#jagged-left-stroke {
+		stroke: currentcolor;
+		stroke-width: 0.5px;
+	}
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import "./globals.css";
 
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Toaster } from "sonner";
+import { JaggedClipDefs } from "@/components/JaggedClipDefs";
 import AppSidebar from "@/components/nav/app-sidebar";
 import { Banner } from "@/components/ui/banner";
 import {
@@ -60,6 +61,7 @@ export default function RootLayout({
 					"bg-gradient-to-tl from-[#EEEEEE] to-[#EAEFF2]",
 				)}
 			>
+				<JaggedClipDefs />
 				<NuqsAdapter>
 					<AppRouterCacheProvider>
 						<ThemeProvider theme={theme}>

--- a/src/components/JaggedClipDefs.tsx
+++ b/src/components/JaggedClipDefs.tsx
@@ -1,0 +1,110 @@
+export function JaggedClipDefs() {
+	return (
+		<svg
+			width="0"
+			height="0"
+			style={{ position: "absolute" }}
+			aria-hidden="true"
+		>
+			<defs>
+				{/* Masks that preserve time column */}
+				<mask
+					id="jagged-mask-right"
+					maskUnits="objectBoundingBox"
+					maskContentUnits="objectBoundingBox"
+				>
+					<rect x="0" y="0" width="0.08" height="1" fill="white" />
+					{/* Data area with right jagged edge */}
+					<polygon
+						fill="white"
+						points="0.08,0 0.98,0 1,0.05 0.98,0.1 1,0.15 0.98,0.2 1,0.25 0.98,0.3 
+                     1,0.35 0.98,0.4 1,0.45 0.98,0.5 1,0.55 0.98,0.6 1,0.65 0.98,0.7 
+                     1,0.75 0.98,0.8 1,0.85 0.98,0.9 1,0.95 0.98,1 
+                     0.08,1"
+					/>
+				</mask>
+
+				<mask
+					id="jagged-mask-left"
+					maskUnits="objectBoundingBox"
+					maskContentUnits="objectBoundingBox"
+				>
+					<rect x="0" y="0" width="0.08" height="1" fill="white" />
+					{/* Data area with left jagged edge */}
+					<polygon
+						fill="white"
+						points="0.10,0 1,0 1,1 0.10,1 0.08,0.95 0.10,0.9 0.08,0.85 0.10,0.8 
+                     0.08,0.75 0.10,0.7 0.08,0.65 0.10,0.6 0.08,0.55 0.10,0.5 
+                     0.08,0.45 0.10,0.4 0.08,0.35 0.10,0.3 0.08,0.25 0.10,0.2 
+                     0.08,0.15 0.10,0.1 0.08,0.05 0.10,0"
+					/>
+				</mask>
+
+				<mask
+					id="jagged-mask-both"
+					maskUnits="objectBoundingBox"
+					maskContentUnits="objectBoundingBox"
+				>
+					<rect x="0" y="0" width="0.08" height="1" fill="white" />
+					{/* Data area with both jagged edges */}
+					<polygon
+						fill="white"
+						points="0.10,0 0.98,0 1,0.05 0.98,0.1 1,0.15 0.98,0.2 1,0.25 0.98,0.3 
+                     1,0.35 0.98,0.4 1,0.45 0.98,0.5 1,0.55 0.98,0.6 1,0.65 0.98,0.7 
+                     1,0.75 0.98,0.8 1,0.85 0.98,0.9 1,0.95 0.98,1 
+                     0.10,1 0.08,0.95 0.10,0.9 0.08,0.85 0.10,0.8 0.08,0.75 0.10,0.7 
+                     0.08,0.65 0.10,0.6 0.08,0.55 0.10,0.5 0.08,0.45 0.10,0.4 
+                     0.08,0.35 0.10,0.3 0.08,0.25 0.10,0.2 0.08,0.15 0.10,0.1 
+                     0.08,0.05 0.10,0"
+					/>
+				</mask>
+
+				<clipPath id="jagged-right" clipPathUnits="objectBoundingBox">
+					<polygon
+						points="0,0 0.08,0 0.98,0 1,0.05 0.98,0.1 1,0.15 0.98,0.2 1,0.25 0.98,0.3 
+                             1,0.35 0.98,0.4 1,0.45 0.98,0.5 1,0.55 0.98,0.6 1,0.65 0.98,0.7 
+                             1,0.75 0.98,0.8 1,0.85 0.98,0.9 1,0.95 0.98,1 1,1 0.08,1 0,1"
+					/>
+				</clipPath>
+
+				<clipPath id="jagged-left" clipPathUnits="objectBoundingBox">
+					<polygon
+						points="0,0 0.10,0 1,0 1,1 0.08,1 0.08,0.95 0.10,0.9 0.08,0.85 0.10,0.8 
+                             0.08,0.75 0.10,0.7 0.08,0.65 0.10,0.6 0.08,0.55 0.10,0.5 
+                             0.08,0.45 0.10,0.4 0.08,0.35 0.10,0.3 0.08,0.25 0.10,0.2 
+                             0.08,0.15 0.10,0.1 0.08,0.05 0.10,0 0,0"
+					/>
+				</clipPath>
+
+				<clipPath id="jagged-both" clipPathUnits="objectBoundingBox">
+					<polygon
+						points="0,0 0.10,0 0.98,0 1,0.05 0.98,0.1 1,0.15 0.98,0.2 1,0.25 0.98,0.3 
+                             1,0.35 0.98,0.4 1,0.45 0.98,0.5 1,0.55 0.98,0.6 1,0.65 0.98,0.7 
+                             1,0.75 0.98,0.8 1,0.85 0.98,0.9 1,0.95 0.98,1 
+                             0.08,1 0.08,0.95 0.10,0.9 0.08,0.85 0.10,0.8 0.08,0.75 0.10,0.7 
+                             0.08,0.65 0.10,0.6 0.08,0.55 0.10,0.5 0.08,0.45 0.10,0.4 
+                             0.08,0.35 0.10,0.3 0.08,0.25 0.10,0.2 0.08,0.15 0.10,0.1 
+                             0.08,0.05 0.10,0 0,0"
+					/>
+				</clipPath>
+
+				{/* Stroke paths for outlines */}
+				<path
+					id="jagged-right-stroke"
+					clipPathUnits="objectBoundingBox"
+					d="M 0.98,0 L 1,0.05 L 0.98,0.1 L 1,0.15 L 0.98,0.2 L 1,0.25 L 0.98,0.3 L 1,0.35 L 0.98,0.4 L 1,0.45 L 0.98,0.5 L 1,0.55 L 0.98,0.6 L 1,0.65 L 0.98,0.7 L 1,0.75 L 0.98,0.8 L 1,0.85 L 0.98,0.9 L 1,0.95 L 0.98,1 L 1,1"
+					fill="none"
+					vectorEffect="non-scaling-stroke"
+				/>
+
+				<path
+					id="jagged-left-stroke"
+					clipPathUnits="objectBoundingBox"
+					d="M 0.10,0 L 0.08,0.05 L 0.10,0.1 L 0.08,0.15 L 0.10,0.2 L 0.08,0.25 L 0.10,0.3 L 0.08,0.35 L 0.10,0.4 L 0.08,0.45 L 0.10,0.5 L 0.08,0.55 L 0.10,0.6 L 0.08,0.65 L 0.10,0.7 L 0.08,0.75 L 0.10,0.8 L 0.08,0.85 L 0.10,0.9 L 0.08,0.95 L 0.10,1 L 0.08,1"
+					fill="none"
+					vectorEffect="non-scaling-stroke"
+				/>
+			</defs>
+		</svg>
+	);
+}

--- a/src/components/JaggedPage.tsx
+++ b/src/components/JaggedPage.tsx
@@ -1,0 +1,43 @@
+export function JaggedOutlineOverlay({
+	isFirstPage,
+	isLastPage,
+	theadHeight = 0,
+}: {
+	isFirstPage: boolean;
+	isLastPage: boolean;
+	theadHeight?: number;
+}) {
+	const getStrokeIds = () => {
+		if (isFirstPage && !isLastPage) return ["jagged-right-stroke"];
+		if (isLastPage && !isFirstPage) return ["jagged-left-stroke"];
+		if (!isFirstPage && !isLastPage)
+			return ["jagged-right-stroke", "jagged-left-stroke"];
+		return [];
+	};
+
+	const strokeIds = getStrokeIds();
+
+	if (strokeIds.length === 0) return null;
+
+	return (
+		<svg
+			className="calendar-jagged-outline"
+			viewBox="0 0 1 1"
+			preserveAspectRatio="none"
+			aria-hidden="true"
+			style={{
+				top: `${theadHeight}px`,
+				height: `calc(100% - ${theadHeight}px + 2px)`,
+			}}
+		>
+			{strokeIds.map((id) => (
+				<use
+					key={id}
+					href={`#${id}`}
+					fill="none"
+					vectorEffect="non-scaling-stroke"
+				/>
+			))}
+		</svg>
+	);
+}

--- a/src/components/availability/table/availability-nav-button.tsx
+++ b/src/components/availability/table/availability-nav-button.tsx
@@ -20,7 +20,7 @@ export const AvailabilityNavButton = memo(
 				)}
 				disabled={disabled}
 			>
-				<span className="text-3xl text-gray-500">
+				<span className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-gray-300 text-gray-500 text-xl hover:border-gray-400">
 					{direction === "left" ? <p> &lsaquo;</p> : <p>&rsaquo;</p>}
 				</span>
 			</button>

--- a/src/components/creation/calendar/calendar.tsx
+++ b/src/components/creation/calendar/calendar.tsx
@@ -137,7 +137,9 @@ export function Calendar({
 						onClick={decrementMonth}
 						className="bg-transparent p-3 hover:bg-transparent"
 					>
-						<span className="text-3xl text-gray-500">&lsaquo;</span>
+						<span className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-gray-300 text-gray-500 text-xl hover:border-gray-400">
+							&lsaquo;
+						</span>
 					</Button>
 				)}
 
@@ -184,7 +186,9 @@ export function Calendar({
 						onClick={incrementMonth}
 						className="bg-transparent p-3 hover:bg-transparent"
 					>
-						<span className="text-3xl text-gray-500">&rsaquo;</span>
+						<span className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-gray-300 text-gray-500 text-xl hover:border-gray-400">
+							&rsaquo;
+						</span>
 					</Button>
 				)}
 			</div>


### PR DESCRIPTION
# Overview
Added jagged edges to the schedule table to indicate when there are multiple pages ( > 5 days of availability). Encircled arrows on the availability and calendar page to make the pagination more visible. 

# Testing Summary
When there are multiple pages, the first page has a jagged right edge, middle pages have both sides, and the last page has a left jagged edge. 
<img width="700" height="408" alt="image" src="https://github.com/user-attachments/assets/a73e6c74-66a8-4a80-bf3c-28a97faffbfa" />
<img width="700" height="405" alt="image" src="https://github.com/user-attachments/assets/c67058f8-bdd6-4119-82e7-564ba08de942" />
<img width="700" height="406" alt="image" src="https://github.com/user-attachments/assets/d67e7fb8-453f-4368-bab2-55a4e1a3880f" />

