### PR TITLE
feat: ✨ migrate app shell to MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
 		"@hookform/resolvers": "^3.9.1",
+		"@mui/icons-material": "^7.3.7",
 		"@mui/material": "^7.3.6",
 		"@mui/material-nextjs": "^7.3.6",
 		"@node-rs/argon2": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.54.2(react@19.2.3))
+      '@mui/icons-material':
+        specifier: ^7.3.7
+        version: 7.3.7(@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
       '@mui/material':
         specifier: ^7.3.6
         version: 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1091,6 +1094,17 @@ packages:
 
   '@mui/core-downloads-tracker@7.3.6':
     resolution: {integrity: sha512-QaYtTHlr8kDFN5mE1wbvVARRKH7Fdw1ZuOjBJcFdVpfNfRYKF3QLT4rt+WaB6CKJvpqxRsmEo0kpYinhH5GeHg==}
+
+  '@mui/icons-material@7.3.7':
+    resolution: {integrity: sha512-3Q+ulAqG+A1+R4ebgoIs7AccaJhIGy+Xi/9OnvX376jQ6wcy+rz4geDGrxQxCGzdjOQr4Z3NgyFSZCz4T999lA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.3.7
+      '@types/react': 19.2.7
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/material-nextjs@7.3.6':
     resolution: {integrity: sha512-2fP1QyBRY9rT02/ykNw0yz9aAWy5ZVp+YzkLEqio9VTkIYkon/xSUQX7PfHLOWUbKlkwoKtCQOjsvrYtSOyKnQ==}
@@ -4640,6 +4654,14 @@ snapshots:
       - supports-color
 
   '@mui/core-downloads-tracker@7.3.6': {}
+
+  '@mui/icons-material@7.3.7(@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
 
   '@mui/material-nextjs@7.3.6(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,0 +1,7 @@
+export default function GroupsPage() {
+	return (
+		<div className="px-8 py-8">
+			<h1 className="font-medium font-montserrat text-3xl">Groups</h1>
+		</div>
+	);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,32 +1,16 @@
 import { ThemeProvider } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v16-appRouter";
 import type { Metadata } from "next";
-import { DM_Sans, Montserrat } from "next/font/google";
 import localFont from "next/font/local";
 
 import "./globals.css";
 
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Toaster } from "sonner";
-import AppSidebar from "@/components/nav/app-sidebar";
+import AppShellWrapper from "@/components/nav/app-shell-wrapper";
 import { Banner } from "@/components/ui/banner";
-import {
-	SidebarInset,
-	SidebarProvider,
-	SidebarTrigger,
-} from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
-import theme from "@/theme";
-
-const montserrat = Montserrat({
-	subsets: ["latin"],
-	variable: "--font-montserrat",
-});
-
-const dmSans = DM_Sans({
-	subsets: ["latin"],
-	variable: "--font-dm-sans",
-});
+import theme, { dmSans, montserrat } from "@/theme";
 
 const geistSans = localFont({
 	src: "./fonts/GeistVF.woff",
@@ -53,38 +37,29 @@ export default function RootLayout({
 	children: React.ReactNode;
 }>) {
 	return (
-		<html lang="en">
+		<html lang="en" className={`${dmSans.className} ${montserrat.className}`}>
 			<body
 				className={cn(
-					`${geistSans.variable} ${geistMono.variable} ${montserrat.variable} ${dmSans.variable} antialiased`,
+					`${geistSans.variable} ${geistMono.variable} antialiased`,
 					"bg-gradient-to-tl from-[#EEEEEE] to-[#EAEFF2]",
 				)}
 			>
 				<NuqsAdapter>
 					<AppRouterCacheProvider>
 						<ThemeProvider theme={theme}>
-							<SidebarProvider>
-								<AppSidebar />
-								<SidebarInset>
-									<header className="flex h-16 shrink-0 items-center justify-end gap-2 border-b border-opacity-50 bg-gray-50 drop-shadow-sm md:hidden">
-										<div className="flex items-center gap-2 px-4">
-											<SidebarTrigger className="-ml-1" />
-										</div>
-									</header>
-
-									<div className="h-full rounded-tl-xl bg-gray-50">
-										<Banner
-											chip="ALPHA"
-											storageKey="creation-alpha-banner-dismissed"
-											className="mx-4 mt-4"
-										>
-											ZotMeet is currently in alpha. You may experience bugs or
-											unexpected behavior.
-										</Banner>
-										{children}
-									</div>
-								</SidebarInset>
-							</SidebarProvider>
+							<AppShellWrapper>
+								<div className="h-full rounded-tl-xl bg-gray-50">
+									<Banner
+										chip="ALPHA"
+										storageKey="creation-alpha-banner-dismissed"
+										className="mx-4 mt-4"
+									>
+										ZotMeet is currently in alpha. You may experience bugs or
+										unexpected behavior.
+									</Banner>
+									{children}
+								</div>
+							</AppShellWrapper>
 
 							<Toaster />
 						</ThemeProvider>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+	return (
+		<div className="px-8 py-8">
+			<h1 className="font-medium font-montserrat text-3xl">Profile</h1>
+		</div>
+	);
+}

--- a/src/components/nav/app-shell-wrapper.tsx
+++ b/src/components/nav/app-shell-wrapper.tsx
@@ -1,0 +1,14 @@
+import { getCurrentSession } from "@/lib/auth";
+import { MuiAppShell } from "./mui-app-shell";
+
+type AppShellWrapperProps = {
+	children: React.ReactNode;
+};
+
+export default async function AppShellWrapper({
+	children,
+}: AppShellWrapperProps) {
+	const { user } = await getCurrentSession();
+
+	return <MuiAppShell user={user}>{children}</MuiAppShell>;
+}

--- a/src/components/nav/mui-app-shell.tsx
+++ b/src/components/nav/mui-app-shell.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Box, useMediaQuery, useTheme } from "@mui/material";
+import type { UserProfile } from "@/lib/auth/user";
+import { MuiBottomNav } from "./mui-bottom-nav";
+import { MuiDrawer } from "./mui-drawer";
+
+type MuiAppShellProps = {
+	user: UserProfile | null;
+	children: React.ReactNode;
+};
+
+export function MuiAppShell({ user, children }: MuiAppShellProps) {
+	const theme = useTheme();
+	const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+	return (
+		<Box sx={{ display: "flex", minHeight: "100vh" }}>
+			{/* Desktop: Show Drawer */}
+			{!isMobile && <MuiDrawer user={user} />}
+
+			{/* Main Content */}
+			<Box
+				component="main"
+				sx={{
+					flexGrow: 1,
+					width: "100%",
+					pb: isMobile ? 8 : 0, // Add padding bottom for mobile nav
+				}}
+			>
+				{children}
+			</Box>
+
+			{/* Mobile: Show Bottom Navigation */}
+			{isMobile && <MuiBottomNav />}
+		</Box>
+	);
+}

--- a/src/components/nav/mui-app-shell.tsx
+++ b/src/components/nav/mui-app-shell.tsx
@@ -16,22 +16,18 @@ export function MuiAppShell({ user, children }: MuiAppShellProps) {
 
 	return (
 		<Box sx={{ display: "flex", minHeight: "100vh" }}>
-			{/* Desktop: Show Drawer */}
 			{!isMobile && <MuiDrawer user={user} />}
 
-			{/* Main Content */}
 			<Box
 				component="main"
 				sx={{
 					flexGrow: 1,
 					width: "100%",
-					pb: isMobile ? 8 : 0, // Add padding bottom for mobile nav
+					pb: isMobile ? 8 : 0,
 				}}
 			>
 				{children}
 			</Box>
-
-			{/* Mobile: Show Bottom Navigation */}
 			{isMobile && <MuiBottomNav />}
 		</Box>
 	);

--- a/src/components/nav/mui-bottom-nav.tsx
+++ b/src/components/nav/mui-bottom-nav.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+	AddCircleOutline,
+	CalendarMonth,
+	Groups,
+	Person,
+} from "@mui/icons-material";
+import { BottomNavigation, BottomNavigationAction, Paper } from "@mui/material";
+import { usePathname, useRouter } from "next/navigation";
+
+const navItems = [
+	{ label: "New", value: "/", icon: AddCircleOutline },
+	{ label: "Summary", value: "/summary", icon: CalendarMonth },
+	{ label: "Groups", value: "/groups", icon: Groups },
+	{ label: "Profile", value: "/profile", icon: Person },
+];
+
+export function MuiBottomNav() {
+	const pathname = usePathname();
+	const router = useRouter();
+
+	const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+		router.push(newValue);
+	};
+
+	return (
+		<Paper
+			sx={{
+				position: "fixed",
+				bottom: 0,
+				left: 0,
+				right: 0,
+				zIndex: 1000,
+			}}
+			elevation={3}
+		>
+			<BottomNavigation value={pathname} onChange={handleChange} showLabels>
+				{navItems.map((item) => {
+					const Icon = item.icon;
+					return (
+						<BottomNavigationAction
+							key={item.value}
+							label={item.label}
+							value={item.value}
+							icon={<Icon />}
+						/>
+					);
+				})}
+			</BottomNavigation>
+		</Paper>
+	);
+}

--- a/src/components/nav/mui-drawer.tsx
+++ b/src/components/nav/mui-drawer.tsx
@@ -24,6 +24,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { AuthDialog } from "@/components/auth/auth-dialog";
 import type { UserProfile } from "@/lib/auth/user";
 import { logoutAction } from "@/server/actions/auth/logout/action";
 
@@ -44,6 +45,7 @@ type MuiDrawerProps = {
 export function MuiDrawer({ user }: MuiDrawerProps) {
 	const [open, setOpen] = useState(false);
 	const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+	const [authDialogOpen, setAuthDialogOpen] = useState(false);
 	const pathname = usePathname();
 	const menuOpen = Boolean(anchorEl);
 
@@ -158,87 +160,91 @@ export function MuiDrawer({ user }: MuiDrawerProps) {
 				})}
 			</List>
 
-			{/* User Menu at Bottom */}
-			{user && (
-				<Box sx={{ p: 1 }}>
-					<Box
-						onClick={handleUserMenuClick}
-						sx={{
-							display: "flex",
-							alignItems: "center",
-							gap: 2,
-							p: 1.5,
-							cursor: "pointer",
-							borderRadius: 2,
-							"&:hover": {
-								bgcolor: "rgba(0, 0, 0, 0.08)",
-							},
-							justifyContent: open ? "flex-start" : "center",
-						}}
-					>
-						<Avatar
+			{/* User Menu / Login at Bottom */}
+			<Box sx={{ p: 1 }}>
+				{user ? (
+					<>
+						<Box
+							onClick={handleUserMenuClick}
 							sx={{
-								width: 32,
-								height: 32,
-								bgcolor: "rgba(0, 0, 0, 0.1)",
-								color: "rgba(0, 0, 0, 0.6)",
+								display: "flex",
+								alignItems: "center",
+								gap: 2,
+								p: 1.5,
+								cursor: "pointer",
+								borderRadius: 2,
+								"&:hover": {
+									bgcolor: "rgba(0, 0, 0, 0.08)",
+								},
+								justifyContent: open ? "flex-start" : "center",
 							}}
 						>
-							<Person />
-						</Avatar>
-						{open && (
-							<Box sx={{ flexGrow: 1, minWidth: 0 }}>
-								<Typography
-									variant="body2"
-									sx={{
-										fontWeight: 600,
-										overflow: "hidden",
-										textOverflow: "ellipsis",
-										whiteSpace: "nowrap",
-									}}
-								>
-									{user.displayName}
-								</Typography>
-								<Typography
-									variant="caption"
-									sx={{
-										color: "text.secondary",
-										overflow: "hidden",
-										textOverflow: "ellipsis",
-										whiteSpace: "nowrap",
-										display: "block",
-									}}
-								>
-									{user.email}
-								</Typography>
-							</Box>
-						)}
-					</Box>
+							<Avatar
+								sx={{
+									width: 32,
+									height: 32,
+									bgcolor: "rgba(0, 0, 0, 0.1)",
+									color: "rgba(0, 0, 0, 0.6)",
+								}}
+							>
+								<Person />
+							</Avatar>
+							{open && (
+								<Box sx={{ flexGrow: 1, minWidth: 0 }}>
+									<Typography
+										variant="body2"
+										sx={{
+											fontWeight: 600,
+											overflow: "hidden",
+											textOverflow: "ellipsis",
+											whiteSpace: "nowrap",
+										}}
+									>
+										{user.displayName}
+									</Typography>
+									<Typography
+										variant="caption"
+										sx={{
+											color: "text.secondary",
+											overflow: "hidden",
+											textOverflow: "ellipsis",
+											whiteSpace: "nowrap",
+											display: "block",
+										}}
+									>
+										{user.email}
+									</Typography>
+								</Box>
+							)}
+						</Box>
 
-					<Menu
-						anchorEl={anchorEl}
-						open={menuOpen}
-						onClose={handleUserMenuClose}
-						anchorOrigin={{
-							vertical: "top",
-							horizontal: "right",
-						}}
-						transformOrigin={{
-							vertical: "bottom",
-							horizontal: "left",
-						}}
-					>
-						<MenuItem
-							component={Link}
-							href="/profile"
-							onClick={handleUserMenuClose}
+						<Menu
+							anchorEl={anchorEl}
+							open={menuOpen}
+							onClose={handleUserMenuClose}
+							anchorOrigin={{
+								vertical: "top",
+								horizontal: "right",
+							}}
+							transformOrigin={{
+								vertical: "bottom",
+								horizontal: "left",
+							}}
 						>
-							<Person sx={{ mr: 1 }} /> Profile
-						</MenuItem>
-						<MenuItem onClick={handleLogout}>Log out</MenuItem>
-					</Menu>
-				</Box>
-			)}
+							<MenuItem
+								component={Link}
+								href="/profile"
+								onClick={handleUserMenuClose}
+							>
+								<Person sx={{ mr: 1 }} /> Profile
+							</MenuItem>
+							<MenuItem onClick={handleLogout}>Log out</MenuItem>
+						</Menu>
+					</>
+				) : (
+					<AuthDialog open={authDialogOpen} setOpen={setAuthDialogOpen} />
+				)}
+			</Box>
 		</Drawer>
 	);
 }

--- a/src/components/nav/mui-drawer.tsx
+++ b/src/components/nav/mui-drawer.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import {
+	AddCircleOutline,
+	CalendarMonth,
+	Groups,
+	Person,
+} from "@mui/icons-material";
+import {
+	Avatar,
+	Box,
+	Divider,
+	Drawer,
+	List,
+	ListItem,
+	ListItemButton,
+	ListItemIcon,
+	ListItemText,
+	Menu,
+	MenuItem,
+	Typography,
+} from "@mui/material";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import type { UserProfile } from "@/lib/auth/user";
+import { logoutAction } from "@/server/actions/auth/logout/action";
+
+const drawerWidth = 240;
+const miniDrawerWidth = 72;
+
+const navItems = [
+	{ title: "New Meeting", url: "/", icon: AddCircleOutline },
+	{ title: "Summary", url: "/summary", icon: CalendarMonth },
+	{ title: "Groups", url: "/groups", icon: Groups },
+	{ title: "Profile", url: "/profile", icon: Person },
+];
+
+type MuiDrawerProps = {
+	user: UserProfile | null;
+};
+
+export function MuiDrawer({ user }: MuiDrawerProps) {
+	const [open, setOpen] = useState(false);
+	const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+	const pathname = usePathname();
+	const menuOpen = Boolean(anchorEl);
+
+	const handleUserMenuClick = (event: React.MouseEvent<HTMLDivElement>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleUserMenuClose = () => {
+		setAnchorEl(null);
+	};
+
+	const handleLogout = () => {
+		handleUserMenuClose();
+		logoutAction();
+	};
+
+	return (
+		<Drawer
+			variant="permanent"
+			sx={{
+				width: open ? drawerWidth : miniDrawerWidth,
+				flexShrink: 0,
+				"& .MuiDrawer-paper": {
+					width: open ? drawerWidth : miniDrawerWidth,
+					boxSizing: "border-box",
+					transition: "width 0.2s",
+					overflowX: "hidden",
+					background: "linear-gradient(to top left, #EEEEEE, #EAEFF2)",
+					borderRight: "none",
+				},
+			}}
+			onMouseEnter={() => setOpen(true)}
+			onMouseLeave={() => setOpen(false)}
+		>
+			{/* Logo Header */}
+			<Box sx={{ p: 2, display: "flex", alignItems: "center", gap: 2 }}>
+				<Box
+					sx={{
+						position: "relative",
+						width: 40,
+						height: 40,
+						flexShrink: 0,
+						border: "1px solid black",
+						borderRadius: 1,
+					}}
+				>
+					<Image src="/ZotMeet_BLACK.png" fill alt="ZotMeet logo" />
+				</Box>
+				{open && (
+					<Typography
+						variant="h4"
+						sx={{
+							fontWeight: 600,
+							fontSize: "2rem",
+							whiteSpace: "nowrap",
+						}}
+					>
+						ZotMeet
+					</Typography>
+				)}
+			</Box>
+
+			<Divider sx={{ bgcolor: "rgba(0, 0, 0, 0.2)", height: 2 }} />
+
+			{/* Navigation Items */}
+			<List sx={{ flexGrow: 1, pt: 2 }}>
+				{navItems.map((item) => {
+					const isActive = pathname === item.url;
+					const Icon = item.icon;
+
+					return (
+						<ListItem key={item.title} disablePadding sx={{ px: 1 }}>
+							<ListItemButton
+								component={Link}
+								href={item.url}
+								selected={isActive}
+								sx={{
+									borderRadius: 3,
+									minHeight: 48,
+									px: 2,
+									justifyContent: open ? "initial" : "center",
+									"&.Mui-selected": {
+										bgcolor: "rgba(0, 0, 0, 0.08)",
+									},
+									"&:hover": {
+										bgcolor: "rgba(0, 0, 0, 0.12)",
+									},
+								}}
+							>
+								<ListItemIcon
+									sx={{
+										minWidth: 0,
+										mr: open ? 3 : "auto",
+										justifyContent: "center",
+										color: "rgba(0, 0, 0, 0.6)",
+									}}
+								>
+									<Icon />
+								</ListItemIcon>
+								{open && (
+									<ListItemText
+										primary={item.title}
+										primaryTypographyProps={{
+											fontSize: "1.125rem",
+											fontWeight: 500,
+										}}
+									/>
+								)}
+							</ListItemButton>
+						</ListItem>
+					);
+				})}
+			</List>
+
+			{/* User Menu at Bottom */}
+			{user && (
+				<Box sx={{ p: 1 }}>
+					<Box
+						onClick={handleUserMenuClick}
+						sx={{
+							display: "flex",
+							alignItems: "center",
+							gap: 2,
+							p: 1.5,
+							cursor: "pointer",
+							borderRadius: 2,
+							"&:hover": {
+								bgcolor: "rgba(0, 0, 0, 0.08)",
+							},
+							justifyContent: open ? "flex-start" : "center",
+						}}
+					>
+						<Avatar
+							sx={{
+								width: 32,
+								height: 32,
+								bgcolor: "rgba(0, 0, 0, 0.1)",
+								color: "rgba(0, 0, 0, 0.6)",
+							}}
+						>
+							<Person />
+						</Avatar>
+						{open && (
+							<Box sx={{ flexGrow: 1, minWidth: 0 }}>
+								<Typography
+									variant="body2"
+									sx={{
+										fontWeight: 600,
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+									}}
+								>
+									{user.displayName}
+								</Typography>
+								<Typography
+									variant="caption"
+									sx={{
+										color: "text.secondary",
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+										display: "block",
+									}}
+								>
+									{user.email}
+								</Typography>
+							</Box>
+						)}
+					</Box>
+
+					<Menu
+						anchorEl={anchorEl}
+						open={menuOpen}
+						onClose={handleUserMenuClose}
+						anchorOrigin={{
+							vertical: "top",
+							horizontal: "right",
+						}}
+						transformOrigin={{
+							vertical: "bottom",
+							horizontal: "left",
+						}}
+					>
+						<MenuItem
+							component={Link}
+							href="/profile"
+							onClick={handleUserMenuClose}
+						>
+							<Person sx={{ mr: 1 }} /> Profile
+						</MenuItem>
+						<MenuItem onClick={handleLogout}>Log out</MenuItem>
+					</Menu>
+				</Box>
+			)}
+		</Drawer>
+	);
+}

--- a/src/components/nav/mui-drawer.tsx
+++ b/src/components/nav/mui-drawer.tsx
@@ -35,7 +35,6 @@ const navItems = [
 	{ title: "New Meeting", url: "/", icon: AddCircleOutline },
 	{ title: "Summary", url: "/summary", icon: CalendarMonth },
 	{ title: "Groups", url: "/groups", icon: Groups },
-	{ title: "Profile", url: "/profile", icon: Person },
 ];
 
 type MuiDrawerProps = {
@@ -160,7 +159,6 @@ export function MuiDrawer({ user }: MuiDrawerProps) {
 				})}
 			</List>
 
-			{/* User Menu / Login at Bottom */}
 			<Box sx={{ p: 1 }}>
 				{user ? (
 					<>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,63 @@
 "use client";
 
 import { createTheme } from "@mui/material/styles";
+import { DM_Sans, Montserrat } from "next/font/google";
+
+export const dmSans = DM_Sans({
+	subsets: ["latin"],
+	display: "swap",
+	weight: ["400", "500", "600", "700"],
+});
+
+export const montserrat = Montserrat({
+	subsets: ["latin"],
+	display: "swap",
+	weight: ["400", "500", "600", "700"],
+});
 
 const theme = createTheme({
 	typography: {
-		fontFamily: "var(--font-dm-sans)",
+		fontFamily: dmSans.style.fontFamily,
+		h1: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "2.5rem",
+			fontWeight: 600,
+		},
+		h2: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "2rem",
+			fontWeight: 600,
+		},
+		h3: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "1.75rem",
+			fontWeight: 600,
+		},
+		h4: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "1.5rem",
+			fontWeight: 600,
+		},
+		h5: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "1.25rem",
+			fontWeight: 600,
+		},
+		h6: {
+			fontFamily: montserrat.style.fontFamily,
+			fontSize: "1rem",
+			fontWeight: 600,
+		},
+		body1: {
+			fontFamily: dmSans.style.fontFamily,
+		},
+		body2: {
+			fontFamily: dmSans.style.fontFamily,
+		},
+		button: {
+			fontFamily: dmSans.style.fontFamily,
+			fontWeight: 500,
+		},
 	},
 });
 


### PR DESCRIPTION
## Description
Migrated application shell to MUI components. Switched the previous desktop sidebar to the MUI drawer component, which now expands on hover and minimizes on exit. Added the user menu MUI component, which appears when the user profile icon/name is clicked. Mobile view now has a bottom navigation bar with pages for new meeting, summary, groups, and profile. Added routes /groups and /profile as placeholder pages.

## Recording/Screenshots
Desktop MUI drawer and user menu:

https://github.com/user-attachments/assets/3beea069-3076-45c3-a84e-96ccd54b22d1



### Before
Mobile:
Expanding sidebar. 
<img width="301" height="650" alt="IMG_0049" src="https://github.com/user-attachments/assets/312cd6ab-4337-4e2d-889f-a8c5f724c22a" />
Desktop had a permanent full-sized sidebar and user menu with only a logout option. 


### After
Mobile:
Permanent bottom navigation bar. 
<img width="301" height="650" alt="IMG_0046" src="https://github.com/user-attachments/assets/afe0ad38-4bbc-4e0d-84c7-7129307a3806" />
Desktop now has an expanding MUI sidebar with a groups tab, and MUI user menu with a profile page (seen in screen recording above). 

## Test Plan
Test create meeting & summary functionality on mobile to check for regressions (already done on desktop locally). Delete old app shell & nav files once finished.

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #264

<!-- ## Future Follow-Up -->
