### PR TITLE
fix: 🐛 cancel editing after selecting available times no longer shows…

### DIFF
--- a/src/lib/zotdate.ts
+++ b/src/lib/zotdate.ts
@@ -450,7 +450,12 @@ export class ZotDate {
 			this.latestTime,
 			this.isSelected,
 			[...this.availability],
-			{ ...this.groupAvailability },
+			Object.fromEntries(
+				Object.entries(this.groupAvailability).map(([key, value]) => [
+					key,
+					[...value],
+				]),
+			),
 		);
 		return clonedDate;
 	}


### PR DESCRIPTION
When you cancel the selection of availability times, the frontend no longer incorrectly shows a "ghost" availability.

## Description

- `handleCancelEditing` was refactored and now does the following
  - Generates a `cleanedDates` map which contains all availabilities that **does not have your ID associated with it**
    - A clone of the existing zotDate map is created `const cloned = zotDate.clone();`
    - We filter through and reconstruct a new map with all the timestamps and `memberId`'s associated with those timestamps, except for those that match your own `memberId`. availability.tsx:269-277
    - Then, we filter out all timestamps that don't have a `memberId` associated with the timestamp `.filter(([, memberIds]) => memberIds.length > 0)` (Essentially, all those timestamps that were associated with your `memberId`).
  - The availability dates are then set as the new `cleanedDates` map without the "ghost" availabilities.

## Screenshots
Below: A video demonstrating that canceling does not leave "ghost" availabilities.

https://github.com/user-attachments/assets/14eceed3-4aa7-4180-829f-c9dae9300345

## Test Plan
- Test all new behavior described
- Test that existing related behavior still works as intended

## Issues

Closes #224 

This is my 2nd PR, so any feedback for how to improve going forward is very much appreciated! Thanks!