### PR TITLE
feat: redirect user to oauth upon add availability #284

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+.pnpm-store
 /.pnp
 .pnp.js
 .yarn/install-state.gz

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -11,6 +11,7 @@ import {
 	DeleteIcon,
 	EditIcon,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { AuthDialog } from "@/components/auth/auth-dialog";
@@ -45,6 +46,8 @@ export function AvailabilityHeader({
 	setChangeableTimezone,
 	setTimezone,
 }: AvailabilityHeaderProps) {
+	const router = useRouter();
+
 	const {
 		hasAvailability,
 		availabilityView,
@@ -281,6 +284,7 @@ export function AvailabilityHeader({
 									onClick={() => {
 										if (!user) {
 											setIsAuthModalOpen(true);
+											router.push("/auth/login/google");
 											return;
 										}
 										setChangeableTimezone(false);


### PR DESCRIPTION
## Description
- Clicking **Add Availability** while not signed in shall redirect the user to login and back to the meeting page.


## Recording/Screenshots

https://github.com/user-attachments/assets/97dc2a8b-ab7b-4e7f-825e-0f405f6fd7ee



## Test Plan
Without being logged in, go to a valid meeting page and click **Add Availability**. Ensure that login is successful and redirects back to the same meeting 
