### PR TITLE
feat: ✨ oauth redirect env var, prod deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,6 +25,7 @@ env:
   # OIDC Configuration
   OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
   OIDC_ISSUER_URL: ${{ secrets.OIDC_ISSUER_URL }}
+  GOOGLE_OAUTH_REDIRECT_URI: ${{ secrets.GOOGLE_OAUTH_REDIRECT_URI }}
 
 jobs:
   deploy:
@@ -45,7 +46,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Migrate database
-      #  run: pnpm db:migrate
+        run: pnpm db:migrate
 
       # TODO (@KevinWu098): Remove this stage once SST fixes compat with Pulumi
       # https://github.com/anomalyco/sst/issues/6314

--- a/src/db/migrations/0001_cloudy_carlie_cooper.sql
+++ b/src/db/migrations/0001_cloudy_carlie_cooper.sql
@@ -1,0 +1,44 @@
+CREATE TYPE "public"."invite_status" AS ENUM('pending', 'accepted', 'declined', 'expired');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_invite_responses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"invite_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"email" text NOT NULL,
+	"status" "invite_status" DEFAULT 'pending' NOT NULL,
+	"responded_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_invites" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"group_id" uuid NOT NULL,
+	"invite_token" text NOT NULL,
+	"inviter_id" text NOT NULL,
+	"invitee_email" text DEFAULT '' NOT NULL,
+	"sent_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp,
+	CONSTRAINT "group_invites_invite_token_unique" UNIQUE("invite_token")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "group_invite_responses" ADD CONSTRAINT "group_invite_responses_invite_id_group_invites_id_fk" FOREIGN KEY ("invite_id") REFERENCES "public"."group_invites"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "group_invite_responses" ADD CONSTRAINT "group_invite_responses_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_inviter_id_users_id_fk" FOREIGN KEY ("inviter_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/src/db/migrations/meta/0001_snapshot.json
+++ b/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,852 @@
+{
+  "id": "17812e2e-ffed-4c19-b796-19aed202ea8e",
+  "prevId": "de52bfe5-e602-4045-a9f3-371d9cde30eb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availabilities": {
+      "name": "availabilities",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_availabilities": {
+          "name": "meeting_availabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "availabilities_member_id_members_id_fk": {
+          "name": "availabilities_member_id_members_id_fk",
+          "tableFrom": "availabilities",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availabilities_meeting_id_meetings_id_fk": {
+          "name": "availabilities_meeting_id_meetings_id_fk",
+          "tableFrom": "availabilities",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "availabilities_member_id_meeting_id_pk": {
+          "name": "availabilities_member_id_meeting_id_pk",
+          "columns": [
+            "member_id",
+            "meeting_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invite_responses": {
+      "name": "group_invite_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_invite_responses_invite_id_group_invites_id_fk": {
+          "name": "group_invite_responses_invite_id_group_invites_id_fk",
+          "tableFrom": "group_invite_responses",
+          "tableTo": "group_invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invite_responses_user_id_users_id_fk": {
+          "name": "group_invite_responses_user_id_users_id_fk",
+          "tableFrom": "group_invite_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_email": {
+          "name": "invitee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_inviter_id_users_id_fk": {
+          "name": "group_invites_inviter_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_invite_token_unique": {
+          "name": "group_invites_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_user_id_users_id_fk": {
+          "name": "groups_user_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled": {
+          "name": "scheduled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_time": {
+          "name": "from_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_time": {
+          "name": "to_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dates": {
+          "name": "dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meeting_type": {
+          "name": "meeting_type",
+          "type": "meeting_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dates'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meetings_group_id_groups_id_fk": {
+          "name": "meetings_group_id_groups_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_host_id_members_id_fk": {
+          "name": "meetings_host_id_members_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "members",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_accounts_provider_id_provider_user_id_pk": {
+          "name": "oauth_accounts_provider_id_provider_user_id_pk",
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_meetings": {
+      "name": "scheduled_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_from_time": {
+          "name": "scheduled_from_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_to_time": {
+          "name": "scheduled_to_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_meetings_meeting_id_meetings_id_fk": {
+          "name": "scheduled_meetings_meeting_id_meetings_id_fk",
+          "tableFrom": "scheduled_meetings",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_access_token": {
+          "name": "oidc_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_refresh_token": {
+          "name": "oidc_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_access_token": {
+          "name": "google_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_access_token_expires_at": {
+          "name": "google_access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_idx_sessions": {
+          "name": "user_idx_sessions",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_member_id_members_id_fk": {
+          "name": "users_member_id_members_id_fk",
+          "tableFrom": "users",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_in_group": {
+      "name": "users_in_group",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_in_group_user_id_users_id_fk": {
+          "name": "users_in_group_user_id_users_id_fk",
+          "tableFrom": "users_in_group",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_in_group_group_id_groups_id_fk": {
+          "name": "users_in_group_group_id_groups_id_fk",
+          "tableFrom": "users_in_group",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_in_group_group_id_user_id_pk": {
+          "name": "users_in_group_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attendance": {
+      "name": "attendance",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "maybe",
+        "declined"
+      ]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": [
+        "member",
+        "admin"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "expired"
+      ]
+    },
+    "public.meeting_type": {
+      "name": "meeting_type",
+      "schema": "public",
+      "values": [
+        "dates",
+        "days"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770255427413,
       "tag": "0000_skinny_karnak",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1772239344839,
+      "tag": "0001_cloudy_carlie_cooper",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -126,6 +126,49 @@ export const groups = pgTable("groups", {
 export type InsertGroup = InferInsertModel<typeof groups>;
 export type SelectGroup = InferSelectModel<typeof groups>;
 
+export const inviteStatusEnum = pgEnum("invite_status", [
+	"pending",
+	"accepted",
+	"declined",
+	"expired",
+]);
+export const groupInvites = pgTable("group_invites", {
+	id: uuid("id").defaultRandom().primaryKey(),
+	groupId: uuid("group_id")
+		.notNull()
+		.references(() => groups.id, { onDelete: "cascade" }),
+	inviteToken: text("invite_token").notNull().unique(),
+	inviterId: text("inviter_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	inviteeEmail: text("invitee_email").notNull().default(""),
+	sentAt: timestamp("sent_at", { mode: "date" }).defaultNow().notNull(),
+	expiresAt: timestamp("expires_at", { mode: "date" }),
+});
+
+export const groupInviteResponses = pgTable("group_invite_responses", {
+	id: uuid("id").defaultRandom().primaryKey(),
+	inviteId: uuid("invite_id")
+		.notNull()
+		.references(() => groupInvites.id, { onDelete: "cascade" }),
+	userId: text("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	email: text("email").notNull(),
+	status: inviteStatusEnum("status").notNull().default("pending"),
+	respondedAt: timestamp("responded_at", { mode: "date" }),
+});
+
+export type InsertGroupInvite = InferInsertModel<typeof groupInvites>;
+export type SelectGroupInvite = InferSelectModel<typeof groupInvites>;
+
+export type InsertGroupInviteResponse = InferInsertModel<
+	typeof groupInviteResponses
+>;
+export type SelectGroupInviteResponse = InferSelectModel<
+	typeof groupInviteResponses
+>;
+
 export const meetingTypeEnum = pgEnum("meeting_type", ["dates", "days"]);
 
 export const meetings = pgTable("meetings", {

--- a/src/server/actions/group/invite/create/action.ts
+++ b/src/server/actions/group/invite/create/action.ts
@@ -1,0 +1,361 @@
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import {
+	groupInviteResponses,
+	groupInvites,
+	type SelectGroup,
+	type SelectGroupInvite,
+	type SelectGroupInviteResponse,
+	usersInGroup,
+} from "@/db/schema";
+import { getCurrentSession } from "@/lib/auth";
+import { getExistingInvite } from "@/server/data/groups/invite-queries";
+import {
+	getExistingGroup,
+	isGroupCreator,
+	isUserInGroup,
+} from "@/server/data/groups/queries";
+//type def
+export type CreateInviteState = {
+	success: boolean;
+	message: string;
+	inviteToken?: string;
+	inviteUrl?: string;
+};
+
+export async function createGroupInvite(
+	groupId: string,
+	// future: for private invites
+	// inviteeEmails: string | string[],
+	expiresInDays?: number,
+): Promise<CreateInviteState> {
+	//check auth
+	const { user } = await getCurrentSession();
+	if (!user) {
+		return {
+			success: false,
+			message: "not logged in",
+		};
+	}
+
+	//check if group exists
+	let group: SelectGroup;
+	try {
+		group = await getExistingGroup(groupId);
+	} catch (_error) {
+		return {
+			success: false,
+			message: "Group not found",
+		};
+	}
+
+	// check if is group creator
+	const groupCreator = await isGroupCreator({
+		userId: user.id,
+		groupId: groupId,
+	});
+	if (!groupCreator) {
+		return {
+			success: false,
+			message: "You do not have permission to invite",
+		};
+	}
+
+	// GENERATE UNIQUE TOKEN FOR Invite
+	const inviteToken = crypto.randomUUID();
+
+	// Calculate expiration date
+	const expiresAt = expiresInDays
+		? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+		: null;
+
+	// Insert Invite to DB
+	try {
+		const [newInvite] = await db
+			.insert(groupInvites)
+			.values({
+				groupId,
+				inviteToken,
+				inviterId: user.id,
+				inviteeEmail: "",
+				expiresAt,
+				sentAt: new Date(),
+			})
+			.returning({ inviteToken: groupInvites.inviteToken });
+
+		revalidatePath("/groups");
+		revalidatePath(`/groups/${groupId}`);
+
+		const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+		const inviteUrl = `${baseUrl}/invite/${newInvite.inviteToken}`;
+
+		console.log("successfully created invite");
+		return {
+			success: true,
+			message: "Invite created successfully",
+			inviteToken: newInvite.inviteToken,
+			inviteUrl,
+		};
+	} catch (error) {
+		console.error("Failed to create invite:", error);
+		const isProduction =
+			process.env.NODE_ENV === "production" &&
+			!process.env.NEXT_PUBLIC_BASE_URL?.includes("staging");
+		const errorDetail =
+			!isProduction && error instanceof Error ? ` (${error.message})` : "";
+		return {
+			success: false,
+			message: `Failed to create invite. Please try again.${errorDetail}`,
+		};
+	}
+}
+
+export type AcceptInviteState = {
+	success: boolean;
+	message: string;
+	groupId?: string;
+};
+
+export type DeclineInviteState = {
+	success: boolean;
+	message: string;
+};
+
+export async function acceptInvite(
+	groupInviteToken: string,
+): Promise<AcceptInviteState> {
+	//verify auth
+	let user: { id: string; email: string | null } | null;
+	try {
+		const session = await getCurrentSession();
+		user = session.user;
+	} catch {
+		return {
+			success: false,
+			message: "Session error. Please sign in again.",
+		};
+	}
+	if (!user) {
+		return {
+			success: false,
+			message: "user not logged in",
+		};
+	}
+
+	//verify valid invite
+	let invite: SelectGroupInvite;
+	try {
+		invite = await getExistingInvite(groupInviteToken);
+	} catch {
+		return {
+			success: false,
+			message: "Invite not found!",
+		};
+	}
+
+	// Check if invite has expired
+	if (invite.expiresAt && invite.expiresAt < new Date()) {
+		return {
+			success: false,
+			message: "This invite has expired.",
+		};
+	}
+
+	try {
+		const [existingResponse] = await db
+			.select()
+			.from(groupInviteResponses)
+			.where(
+				and(
+					eq(groupInviteResponses.inviteId, invite.id),
+					eq(groupInviteResponses.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		// Check if user is already in the group
+		const alreadyInGroup = await isUserInGroup({
+			userId: user.id,
+			groupId: invite.groupId,
+		});
+
+		// If already accepted and in group, return success
+		if (existingResponse?.status === "accepted" && alreadyInGroup) {
+			return {
+				success: true,
+				message: "You are already a member of this group.",
+				groupId: invite.groupId,
+			};
+		}
+
+		//add user to group
+		await db.transaction(async (tx) => {
+			const userEmail = (user.email ?? "").toLowerCase().trim();
+
+			// Update existing response or create new one
+			if (existingResponse) {
+				// Update existing response to accepted
+				await tx
+					.update(groupInviteResponses)
+					.set({
+						status: "accepted",
+						respondedAt: new Date(),
+					})
+					.where(eq(groupInviteResponses.id, existingResponse.id));
+			} else {
+				// Insert new response record
+				await tx.insert(groupInviteResponses).values({
+					inviteId: invite.id,
+					userId: user.id,
+					email: userEmail,
+					status: "accepted",
+					respondedAt: new Date(),
+				});
+			}
+
+			// Add user to group (only if not already in group)
+			if (!alreadyInGroup) {
+				await tx.insert(usersInGroup).values({
+					userId: user.id,
+					groupId: invite.groupId,
+				});
+			}
+		});
+
+		revalidatePath("/groups");
+		revalidatePath(`/groups/${invite.groupId}`);
+		revalidatePath("/summary");
+
+		return {
+			success: true,
+			message: "Successfully joined group!",
+			groupId: invite.groupId,
+		};
+	} catch (error) {
+		console.error("Failed to accept invite:", error);
+		const isProduction =
+			process.env.NODE_ENV === "production" &&
+			!process.env.NEXT_PUBLIC_BASE_URL?.includes("staging");
+		const errorDetail =
+			!isProduction && error instanceof Error ? ` (${error.message})` : "";
+		return {
+			success: false,
+			message: `Error joining group. Please try again.${errorDetail}`,
+		};
+	}
+}
+
+export async function declineInvite(
+	groupInviteToken: string,
+): Promise<DeclineInviteState> {
+	//verify auth
+	let user: { id: string; email: string | null } | null;
+	try {
+		const session = await getCurrentSession();
+		user = session.user;
+	} catch {
+		return {
+			success: false,
+			message: "Session error. Please sign in again.",
+		};
+	}
+	if (!user) {
+		return {
+			success: false,
+			message: "user not logged in",
+		};
+	}
+
+	//verify valid invite
+	let invite: SelectGroupInvite;
+	try {
+		invite = await getExistingInvite(groupInviteToken);
+	} catch {
+		return {
+			success: false,
+			message: "Invite not found!",
+		};
+	}
+
+	// Check if invite has expired
+	if (invite.expiresAt && invite.expiresAt < new Date()) {
+		return {
+			success: false,
+			message: "This invite has expired.",
+		};
+	}
+
+	try {
+		const [existingResponse] = await db
+			.select()
+			.from(groupInviteResponses)
+			.where(
+				and(
+					eq(groupInviteResponses.inviteId, invite.id),
+					eq(groupInviteResponses.userId, user.id),
+				),
+			)
+			.limit(1);
+
+		const alreadyInGroup = await isUserInGroup({
+			userId: user.id,
+			groupId: invite.groupId,
+		});
+
+		await db.transaction(async (tx) => {
+			const userEmail = (user.email ?? "").toLowerCase().trim();
+
+			if (existingResponse) {
+				await tx
+					.update(groupInviteResponses)
+					.set({
+						status: "declined",
+						respondedAt: new Date(),
+					})
+					.where(eq(groupInviteResponses.id, existingResponse.id));
+			} else {
+				await tx.insert(groupInviteResponses).values({
+					inviteId: invite.id,
+					userId: user.id,
+					email: userEmail,
+					status: "declined",
+					respondedAt: new Date(),
+				});
+			}
+
+			if (alreadyInGroup) {
+				await tx
+					.delete(usersInGroup)
+					.where(
+						and(
+							eq(usersInGroup.userId, user.id),
+							eq(usersInGroup.groupId, invite.groupId),
+						),
+					);
+			}
+		});
+
+		revalidatePath("/groups");
+		revalidatePath(`/groups/${invite.groupId}`);
+		revalidatePath("/summary");
+
+		return {
+			success: true,
+			message: "Invite declined successfully.",
+		};
+	} catch (error) {
+		console.error("Failed to decline invite:", error);
+		const isProduction =
+			process.env.NODE_ENV === "production" &&
+			!process.env.NEXT_PUBLIC_BASE_URL?.includes("staging");
+		const errorDetail =
+			!isProduction && error instanceof Error ? ` (${error.message})` : "";
+		return {
+			success: false,
+			message: `Error declining invite. Please try again.${errorDetail}`,
+		};
+	}
+}

--- a/src/server/data/groups/invite-queries.ts
+++ b/src/server/data/groups/invite-queries.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { db } from "@/db";
+import type { SelectGroupInvite } from "@/db/schema";
+
+export async function getExistingInvite(
+	token: string,
+): Promise<SelectGroupInvite> {
+	const invite = await db.query.groupInvites.findFirst({
+		where: (groupInvites, { eq }) => eq(groupInvites.inviteToken, token),
+	});
+
+	if (!invite) {
+		throw new Error("Invite not found");
+	}
+
+	return invite;
+}


### PR DESCRIPTION

## Summary by cubic
Fixes missing sessions on /groups by adding the Google OAuth redirect env var and enabling prod DB migrations. Also adds group invite support with new tables and server actions.

- **New Features**
  - Enable Google OAuth redirect and run DB migrations in the prod deploy to keep sessions working on /groups.
  - Add group invites: schema (group_invites, group_invite_responses, invite_status) and actions (create, accept, decline) with auth, expiry checks, and idempotency.

- **Migration**
  - Set GOOGLE_OAUTH_REDIRECT_URI in GitHub Actions secrets to match your Google OAuth redirect URL.
  - For local dev, run pnpm db:migrate to create the new tables.

<sup>Written for commit 5704928ef3d5158c75466741eb966f35fc424078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

