### PR TITLE
feat: download iCal and add to Outlook 

### DIFF
--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -380,6 +380,7 @@ export function Availability({
 				meetingData={meetingData}
 				user={user}
 				availabilityDates={availabilityDates}
+				scheduledBlocks={scheduledBlocks}
 				onCancel={handleCancelEditing}
 				onSave={handleSuccessfulSave}
 				setChangeableTimezone={setChangeableTimezone}

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -608,7 +608,6 @@ export function Availability({
 				meetingData={meetingData}
 				user={user}
 				availabilityDates={availabilityDates}
-				scheduledBlocks={scheduledBlocks}
 				onCancel={handleCancelEditing}
 				onSave={handleSuccessfulSave}
 				setChangeableTimezone={setChangeableTimezone}

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -608,6 +608,7 @@ export function Availability({
 				meetingData={meetingData}
 				user={user}
 				availabilityDates={availabilityDates}
+				scheduledBlocks={scheduledBlocks}
 				onCancel={handleCancelEditing}
 				onSave={handleSuccessfulSave}
 				setChangeableTimezone={setChangeableTimezone}

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -323,24 +323,25 @@ export function AvailabilityHeader({
 										</span>
 									</Button>
 								)}
-
-								<Button
-									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
-									onClick={async () => {
-										const { success, content, filename } =
-											await getICalFileContent(meetingData.id);
-										if (!success || !content) {
-											toast.error("No scheduled meeting to download.");
-											return;
-										}
-										triggerICalDownload(content, filename);
-									}}
-								>
-									<FileDownload className="!text-lg md:!text-base" />
-									<span className="hidden font-dm-sans md:flex">
-										Download iCal
-									</span>
-								</Button>
+								{isScheduled && (
+									<Button
+										className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
+										onClick={async () => {
+											const { success, content, filename } =
+												await getICalFileContent(meetingData.id);
+											if (!success || !content) {
+												toast.error("No scheduled meeting to download.");
+												return;
+											}
+											triggerICalDownload(content, filename);
+										}}
+									>
+										<FileDownload className="!text-lg md:!text-base" />
+										<span className="hidden font-dm-sans md:flex">
+											Download iCal
+										</span>
+									</Button>
+								)}
 
 								{isOwner && (
 									<Button

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -324,6 +324,24 @@ export function AvailabilityHeader({
 									</Button>
 								)}
 
+								<Button
+									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
+									onClick={async () => {
+										const { success, content, filename } =
+											await getICalFileContent(meetingData.id);
+										if (!success || !content) {
+											toast.error("No scheduled meeting to download.");
+											return;
+										}
+										triggerICalDownload(content, filename);
+									}}
+								>
+									<FileDownload className="!text-lg md:!text-base" />
+									<span className="hidden font-dm-sans md:flex">
+										Download iCal
+									</span>
+								</Button>
+
 								{isOwner && (
 									<Button
 										className="h-8 min-h-fit min-w-fit flex-center px-2 md:px-4 md:py-0"
@@ -354,23 +372,6 @@ export function AvailabilityHeader({
 									<CalendarPlus className="size-5" />
 									<span className="hidden font-dm-sans md:flex">
 										{hasAvailability ? "Edit Availability" : "Add Availability"}
-									</span>
-								</Button>
-								<Button
-									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
-									onClick={async () => {
-										const { success, content, filename } =
-											await getICalFileContent(meetingData.id);
-										if (!success || !content) {
-											toast.error("No scheduled meeting to download.");
-											return;
-										}
-										triggerICalDownload(content, filename);
-									}}
-								>
-									<FileDownload className="!text-lg md:!text-base" />
-									<span className="hidden font-dm-sans md:flex">
-										Download iCal
 									</span>
 								</Button>
 							</>

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -6,6 +6,7 @@ import {
 	deleteScheduledTimeBlock,
 	saveScheduledTimeBlock,
 } from "@actions/meeting/schedule/action";
+import { FileDownload } from "@mui/icons-material";
 import GoogleIcon from "@mui/icons-material/Google";
 import {
 	CalendarCheck,
@@ -22,8 +23,9 @@ import { useShallow } from "zustand/shallow";
 import { DeleteModal } from "@/components/availability/header/delete-modal";
 import { EditModal } from "@/components/availability/header/edit-modal";
 import { Button } from "@/components/ui/button";
-import type { SelectMeeting } from "@/db/schema";
+import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 import type { UserProfile } from "@/lib/auth/user";
+import { downloadICalFile } from "@/lib/ical";
 import { cn } from "@/lib/utils";
 import type { ZotDate } from "@/lib/zotdate";
 import { useAvailabilityViewStore } from "@/store/useAvailabilityViewStore";
@@ -33,6 +35,7 @@ interface AvailabilityHeaderProps {
 	meetingData: SelectMeeting;
 	user: UserProfile | null;
 	availabilityDates: ZotDate[];
+	scheduledBlocks: SelectScheduledMeeting[];
 	onCancel: () => void;
 	onSave: () => void;
 	setChangeableTimezone: (can: boolean) => void;
@@ -43,6 +46,7 @@ export function AvailabilityHeader({
 	meetingData,
 	user,
 	availabilityDates,
+	scheduledBlocks,
 	onCancel,
 	onSave,
 	setChangeableTimezone,
@@ -303,6 +307,15 @@ export function AvailabilityHeader({
 									<CalendarPlus className="size-5" />
 									<span className="hidden font-dm-sans md:flex">
 										{hasAvailability ? "Edit Availability" : "Add Availability"}
+									</span>
+								</Button>
+								<Button
+									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
+									onClick={() => downloadICalFile(meetingData, scheduledBlocks)}
+								>
+									<FileDownload className="!text-lg md:!text-base" />
+									<span className="hidden font-dm-sans md:flex">
+										Download iCal
 									</span>
 								</Button>
 							</>

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -253,7 +253,7 @@ export function AvailabilityHeader({
 									</span>
 								</Button>
 								<Button
-									className="h-8 min-h-fit min-w-fit flex-center gap-1 bg-[#3B82F6] px-2 text-white hover:bg-[#3B82F6]/80 md:px-4 md:py-0"
+									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
 									onClick={() => downloadICalFile(meetingData, scheduledBlocks)}
 								>
 									<FileDownload className="!text-lg md:!text-base" />

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -284,12 +284,13 @@ export function AvailabilityHeader({
 										)}
 										onClick={async () => {
 											try {
-												const { success, link } = await getOutlookCalendarLink({
-													meetingId: meetingData.id,
-													meetingTitle: meetingData.title,
-													meetingDescription: meetingData.description,
-													meetingLocation: meetingData.location,
-												});
+												const { success, link, totalDays } =
+													await getOutlookCalendarLink({
+														meetingId: meetingData.id,
+														meetingTitle: meetingData.title,
+														meetingDescription: meetingData.description,
+														meetingLocation: meetingData.location,
+													});
 
 												if (!success || !link) {
 													toast.error(
@@ -301,7 +302,9 @@ export function AvailabilityHeader({
 												window.open(link, "_blank", "noopener,noreferrer");
 
 												toast.success(
-													"Outlook Calendar link opened! Confirm the event in your calendar.",
+													totalDays > 1
+														? `Outlook Calendar link opened for the first day. Use "Download iCal" for all ${totalDays} days.`
+														: "Outlook Calendar link opened! Confirm the event in your calendar.",
 												);
 											} catch (error) {
 												console.error(

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -2,12 +2,13 @@
 
 import { getGoogleCalendarPrefilledLink } from "@actions/availability/google/calendar/action";
 import { getICalFileContent } from "@actions/availability/ical/action";
+import { getOutlookCalendarLink } from "@actions/availability/outlook/action";
 import { saveAvailability } from "@actions/availability/save/action";
 import {
 	deleteScheduledTimeBlock,
 	saveScheduledTimeBlock,
 } from "@actions/meeting/schedule/action";
-import { FileDownload } from "@mui/icons-material";
+import { CalendarMonth, FileDownload } from "@mui/icons-material";
 import GoogleIcon from "@mui/icons-material/Google";
 import {
 	CalendarCheck,
@@ -272,6 +273,50 @@ export function AvailabilityHeader({
 										<GoogleIcon className="size-5" />
 										<span className="hidden font-dm-sans md:flex">
 											Add to Calendar
+										</span>
+									</Button>
+								)}
+
+								{isScheduled && (
+									<Button
+										className={cn(
+											"h-8 min-h-fit min-w-fit flex-center px-2 md:px-4 md:py-0",
+										)}
+										onClick={async () => {
+											try {
+												const { success, link } = await getOutlookCalendarLink({
+													meetingId: meetingData.id,
+													meetingTitle: meetingData.title,
+													meetingDescription: meetingData.description,
+													meetingLocation: meetingData.location,
+												});
+
+												if (!success || !link) {
+													toast.error(
+														"Failed to generate Outlook Calendar link.",
+													);
+													return;
+												}
+
+												window.open(link, "_blank", "noopener,noreferrer");
+
+												toast.success(
+													"Outlook Calendar link opened! Confirm the event in your calendar.",
+												);
+											} catch (error) {
+												console.error(
+													"Error generating Outlook Calendar link:",
+													error,
+												);
+												toast.error(
+													"An error occurred while generating the Outlook Calendar link.",
+												);
+											}
+										}}
+									>
+										<CalendarMonth className="size-5" />
+										<span className="hidden font-dm-sans md:flex">
+											Add to Outlook
 										</span>
 									</Button>
 								)}

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getGoogleCalendarPrefilledLink } from "@actions/availability/google/calendar/action";
+import { getICalFileContent } from "@actions/availability/ical/action";
 import { saveAvailability } from "@actions/availability/save/action";
 import {
 	deleteScheduledTimeBlock,
@@ -23,9 +24,9 @@ import { useShallow } from "zustand/shallow";
 import { DeleteModal } from "@/components/availability/header/delete-modal";
 import { EditModal } from "@/components/availability/header/edit-modal";
 import { Button } from "@/components/ui/button";
-import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
+import type { SelectMeeting } from "@/db/schema";
 import type { UserProfile } from "@/lib/auth/user";
-import { downloadICalFile } from "@/lib/ical";
+import { triggerICalDownload } from "@/lib/ical";
 import { cn } from "@/lib/utils";
 import type { ZotDate } from "@/lib/zotdate";
 import { useAvailabilityViewStore } from "@/store/useAvailabilityViewStore";
@@ -35,7 +36,6 @@ interface AvailabilityHeaderProps {
 	meetingData: SelectMeeting;
 	user: UserProfile | null;
 	availabilityDates: ZotDate[];
-	scheduledBlocks: SelectScheduledMeeting[];
 	onCancel: () => void;
 	onSave: () => void;
 	setChangeableTimezone: (can: boolean) => void;
@@ -46,7 +46,6 @@ export function AvailabilityHeader({
 	meetingData,
 	user,
 	availabilityDates,
-	scheduledBlocks,
 	onCancel,
 	onSave,
 	setChangeableTimezone,
@@ -311,7 +310,15 @@ export function AvailabilityHeader({
 								</Button>
 								<Button
 									className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
-									onClick={() => downloadICalFile(meetingData, scheduledBlocks)}
+									onClick={async () => {
+										const { success, content, filename } =
+											await getICalFileContent(meetingData.id);
+										if (!success || !content) {
+											toast.error("No scheduled meeting to download.");
+											return;
+										}
+										triggerICalDownload(content, filename);
+									}}
 								>
 									<FileDownload className="!text-lg md:!text-base" />
 									<span className="hidden font-dm-sans md:flex">

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -327,13 +327,20 @@ export function AvailabilityHeader({
 									<Button
 										className="h-8 min-h-fit min-w-fit flex-center gap-1 px-2 md:px-4 md:py-0"
 										onClick={async () => {
-											const { success, content, filename } =
-												await getICalFileContent(meetingData.id);
-											if (!success || !content) {
-												toast.error("No scheduled meeting to download.");
-												return;
+											try {
+												const { success, content, filename } =
+													await getICalFileContent(meetingData.id);
+												if (!success || !content) {
+													toast.error("No scheduled meeting to download.");
+													return;
+												}
+												triggerICalDownload(content, filename);
+											} catch (error) {
+												console.error("Error generating iCal file:", error);
+												toast.error(
+													"An error occurred while generating the iCal file.",
+												);
 											}
-											triggerICalDownload(content, filename);
 										}}
 									>
 										<FileDownload className="!text-lg md:!text-base" />

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -5,6 +5,7 @@ import {
 	deleteScheduledTimeBlock,
 	saveScheduledTimeBlock,
 } from "@actions/meeting/schedule/action";
+import { FileDownload } from "@mui/icons-material";
 import {
 	CalendarCheck,
 	CalendarPlus,
@@ -19,8 +20,9 @@ import { useShallow } from "zustand/shallow";
 import { DeleteModal } from "@/components/availability/header/delete-modal";
 import { EditModal } from "@/components/availability/header/edit-modal";
 import { Button } from "@/components/ui/button";
-import type { SelectMeeting } from "@/db/schema";
+import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 import type { UserProfile } from "@/lib/auth/user";
+import { downloadICalFile } from "@/lib/ical";
 import { cn } from "@/lib/utils";
 import type { ZotDate } from "@/lib/zotdate";
 import { useAvailabilityViewStore } from "@/store/useAvailabilityViewStore";
@@ -30,6 +32,7 @@ interface AvailabilityHeaderProps {
 	meetingData: SelectMeeting;
 	user: UserProfile | null;
 	availabilityDates: ZotDate[];
+	scheduledBlocks: SelectScheduledMeeting[];
 	onCancel: () => void;
 	onSave: () => void;
 	setChangeableTimezone: (can: boolean) => void;
@@ -40,6 +43,7 @@ export function AvailabilityHeader({
 	meetingData,
 	user,
 	availabilityDates,
+	scheduledBlocks,
 	onCancel,
 	onSave,
 	setChangeableTimezone,
@@ -246,6 +250,15 @@ export function AvailabilityHeader({
 									<CalendarPlus className="size-5 md:hidden" />
 									<span className="hidden font-dm-sans md:flex">
 										{hasAvailability ? "Edit Availability" : "Add Availability"}
+									</span>
+								</Button>
+								<Button
+									className="h-8 min-h-fit min-w-fit flex-center gap-1 bg-[#3B82F6] px-2 text-white hover:bg-[#3B82F6]/80 md:px-4 md:py-0"
+									onClick={() => downloadICalFile(meetingData, scheduledBlocks)}
+								>
+									<FileDownload className="!text-lg md:!text-base" />
+									<span className="hidden font-dm-sans md:flex">
+										Download iCal
 									</span>
 								</Button>
 							</>

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -1,0 +1,189 @@
+import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
+
+function formatICalDateTimeUTC(date: Date): string {
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(date.getUTCDate()).padStart(2, "0");
+	const hours = String(date.getUTCHours()).padStart(2, "0");
+	const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+	const seconds = String(date.getUTCSeconds()).padStart(2, "0");
+	return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
+function escapeICalText(text: string): string {
+	return text
+		.replace(/\\/g, "\\\\")
+		.replace(/;/g, "\\;")
+		.replace(/,/g, "\\,")
+		.replace(/\n/g, "\\n");
+}
+
+interface TimeInterval {
+	date: Date;
+	from: string; // "HH:mm:ss"
+	to: string; // "HH:mm:ss"
+}
+
+function mergeScheduledBlocks(
+	blocks: SelectScheduledMeeting[],
+): TimeInterval[] {
+	if (blocks.length === 0) return [];
+
+	const byDate = new Map<string, SelectScheduledMeeting[]>();
+	for (const block of blocks) {
+		const key = block.scheduledDate.toISOString().split("T")[0];
+		if (!byDate.has(key)) byDate.set(key, []);
+		const dateBlocks = byDate.get(key);
+		if (dateBlocks) dateBlocks.push(block);
+	}
+
+	const intervals: TimeInterval[] = [];
+
+	for (const [, dateBlocks] of byDate) {
+		const sorted = [...dateBlocks].sort((a, b) =>
+			a.scheduledFromTime.localeCompare(b.scheduledFromTime),
+		);
+
+		let currentFrom = sorted[0].scheduledFromTime;
+		let currentTo = sorted[0].scheduledToTime;
+		const date = sorted[0].scheduledDate;
+
+		for (let i = 1; i < sorted.length; i++) {
+			if (sorted[i].scheduledFromTime === currentTo) {
+				currentTo = sorted[i].scheduledToTime;
+			} else {
+				intervals.push({ date, from: currentFrom, to: currentTo });
+				currentFrom = sorted[i].scheduledFromTime;
+				currentTo = sorted[i].scheduledToTime;
+			}
+		}
+		intervals.push({ date, from: currentFrom, to: currentTo });
+	}
+
+	return intervals;
+}
+
+function localDateTimeToDate(date: Date, time: string): Date {
+	const parts = time.split(":").map(Number);
+	const h = parts[0];
+	const m = parts[1];
+	const s = parts[2] ?? 0;
+	const d = new Date(date);
+	d.setHours(h, m, s, 0);
+	return d;
+}
+
+export function generateICalString(
+	meetingData: SelectMeeting,
+	scheduledBlocks: SelectScheduledMeeting[] = [],
+): string {
+	const lines: string[] = [
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"PRODID:-//ZotMeet//ZotMeet//EN",
+		"CALSCALE:GREGORIAN",
+		"METHOD:PUBLISH",
+	];
+
+	const title = escapeICalText(meetingData.title);
+	const description = meetingData.description
+		? escapeICalText(meetingData.description)
+		: "";
+	const location = meetingData.location
+		? escapeICalText(meetingData.location)
+		: "";
+
+	const now = formatICalDateTimeUTC(new Date());
+
+	// If there are scheduled blocks, export those as the actual calendar events.
+	// Scheduled blocks are stored in the user's local timezone.
+	if (scheduledBlocks.length > 0) {
+		const intervals = mergeScheduledBlocks(scheduledBlocks);
+
+		for (let i = 0; i < intervals.length; i++) {
+			const interval = intervals[i];
+			const startDate = localDateTimeToDate(interval.date, interval.from);
+			const endDate = localDateTimeToDate(interval.date, interval.to);
+
+			const datePart = interval.date.toISOString().split("T")[0];
+			const uid = `${meetingData.id}-scheduled-${datePart}-${i}@zotmeet`;
+
+			lines.push("BEGIN:VEVENT");
+			lines.push(`UID:${uid}`);
+			lines.push(`DTSTAMP:${now}`);
+			lines.push(`DTSTART:${formatICalDateTimeUTC(startDate)}`);
+			lines.push(`DTEND:${formatICalDateTimeUTC(endDate)}`);
+			lines.push(`SUMMARY:${title}`);
+			if (description) {
+				lines.push(`DESCRIPTION:${description}`);
+			}
+			if (location) {
+				lines.push(`LOCATION:${location}`);
+			}
+			lines.push("END:VEVENT");
+		}
+
+		lines.push("END:VCALENDAR");
+		return lines.join("\r\n");
+	}
+
+	// Fallback: no scheduled blocks — export the meeting availability window.
+	// "days" type meetings use anchor dates (Jan 1-7, 2023) which are not real dates.
+	if (meetingData.meetingType === "days") {
+		lines.push("END:VCALENDAR");
+		return lines.join("\r\n");
+	}
+
+	for (const dateStr of meetingData.dates) {
+		const datePart = dateStr.substring(0, 10);
+		const [hours, minutes, seconds = "00"] = meetingData.fromTime.split(":");
+		const startDate = new Date(`${datePart}T${hours}:${minutes}:${seconds}Z`);
+
+		const [eh, em, es = "00"] = meetingData.toTime.split(":");
+		const endDate = new Date(`${datePart}T${eh}:${em}:${es}Z`);
+
+		// Handle midnight UTC wraparound
+		if (endDate.getTime() <= startDate.getTime()) {
+			endDate.setUTCDate(endDate.getUTCDate() + 1);
+		}
+
+		const uid = `${meetingData.id}-${datePart}@zotmeet`;
+
+		lines.push("BEGIN:VEVENT");
+		lines.push(`UID:${uid}`);
+		lines.push(`DTSTAMP:${now}`);
+		lines.push(`DTSTART:${formatICalDateTimeUTC(startDate)}`);
+		lines.push(`DTEND:${formatICalDateTimeUTC(endDate)}`);
+		lines.push(`SUMMARY:${title}`);
+		if (description) {
+			lines.push(`DESCRIPTION:${description}`);
+		}
+		if (location) {
+			lines.push(`LOCATION:${location}`);
+		}
+		lines.push("END:VEVENT");
+	}
+
+	lines.push("END:VCALENDAR");
+	return lines.join("\r\n");
+}
+
+export function downloadICalFile(
+	meetingData: SelectMeeting,
+	scheduledBlocks: SelectScheduledMeeting[] = [],
+): void {
+	const icalContent = generateICalString(meetingData, scheduledBlocks);
+	const blob = new Blob([icalContent], {
+		type: "text/calendar;charset=utf-8",
+	});
+	const url = URL.createObjectURL(blob);
+
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = `${meetingData.title.replace(/[^a-zA-Z0-9]/g, "_")}.ics`;
+	document.body.appendChild(link);
+	link.click();
+
+	document.body.removeChild(link);
+	URL.revokeObjectURL(url);
+}

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -1,4 +1,8 @@
 import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
+import {
+	getCurrentWeekDateForAnchor,
+	isAnchorDateMeeting,
+} from "@/lib/types/chrono";
 
 function formatICalDateTimeUTC(date: Date): string {
 	const year = date.getUTCFullYear();
@@ -98,14 +102,20 @@ export function generateICalString(
 		: "";
 
 	const now = formatICalDateTimeUTC(new Date());
+	const isDaysOfWeek = isAnchorDateMeeting(meetingData.dates);
 	const intervals = mergeScheduledBlocks(scheduledBlocks);
 
 	for (let i = 0; i < intervals.length; i++) {
 		const interval = intervals[i];
-		const startDate = localDateTimeToDate(interval.date, interval.from);
-		const endDate = localDateTimeToDate(interval.date, interval.to);
 
-		const datePart = interval.date.toISOString().split("T")[0];
+		const eventDate = isDaysOfWeek
+			? getCurrentWeekDateForAnchor(interval.date)
+			: interval.date;
+
+		const startDate = localDateTimeToDate(eventDate, interval.from);
+		const endDate = localDateTimeToDate(eventDate, interval.to);
+
+		const datePart = eventDate.toISOString().split("T")[0];
 		const uid = `${meetingData.id}-scheduled-${datePart}-${i}@zotmeet`;
 
 		lines.push("BEGIN:VEVENT");

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -75,9 +75,9 @@ function pad2(n: number): string {
 
 function getYmd(date: Date): { yyyy: number; mm: string; dd: string } {
 	return {
-		yyyy: date.getFullYear(),
-		mm: pad2(date.getMonth() + 1),
-		dd: pad2(date.getDate()),
+		yyyy: date.getUTCFullYear(),
+		mm: pad2(date.getUTCMonth() + 1),
+		dd: pad2(date.getUTCDate()),
 	};
 }
 

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -127,22 +127,15 @@ export function generateICalString(
 	return lines.join("\r\n");
 }
 
-export function downloadICalFile(
-	meetingData: SelectMeeting,
-	scheduledBlocks: SelectScheduledMeeting[] = [],
-): void {
-	const icalContent = generateICalString(meetingData, scheduledBlocks);
-
-	if (!icalContent) return;
-
-	const blob = new Blob([icalContent], {
+export function triggerICalDownload(content: string, filename: string): void {
+	const blob = new Blob([content], {
 		type: "text/calendar;charset=utf-8",
 	});
 	const url = URL.createObjectURL(blob);
 
 	const link = document.createElement("a");
 	link.href = url;
-	link.download = `${meetingData.title.replace(/[^a-zA-Z0-9]/g, "_")}.ics`;
+	link.download = filename;
 	document.body.appendChild(link);
 	link.click();
 

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -76,7 +76,11 @@ function localDateTimeToDate(date: Date, time: string): Date {
 export function generateICalString(
 	meetingData: SelectMeeting,
 	scheduledBlocks: SelectScheduledMeeting[] = [],
-): string {
+): string | null {
+	if (scheduledBlocks.length === 0) {
+		return null;
+	}
+
 	const lines: string[] = [
 		"BEGIN:VCALENDAR",
 		"VERSION:2.0",
@@ -94,60 +98,15 @@ export function generateICalString(
 		: "";
 
 	const now = formatICalDateTimeUTC(new Date());
+	const intervals = mergeScheduledBlocks(scheduledBlocks);
 
-	// If there are scheduled blocks, export those as the actual calendar events.
-	// Scheduled blocks are stored in the user's local timezone.
-	if (scheduledBlocks.length > 0) {
-		const intervals = mergeScheduledBlocks(scheduledBlocks);
+	for (let i = 0; i < intervals.length; i++) {
+		const interval = intervals[i];
+		const startDate = localDateTimeToDate(interval.date, interval.from);
+		const endDate = localDateTimeToDate(interval.date, interval.to);
 
-		for (let i = 0; i < intervals.length; i++) {
-			const interval = intervals[i];
-			const startDate = localDateTimeToDate(interval.date, interval.from);
-			const endDate = localDateTimeToDate(interval.date, interval.to);
-
-			const datePart = interval.date.toISOString().split("T")[0];
-			const uid = `${meetingData.id}-scheduled-${datePart}-${i}@zotmeet`;
-
-			lines.push("BEGIN:VEVENT");
-			lines.push(`UID:${uid}`);
-			lines.push(`DTSTAMP:${now}`);
-			lines.push(`DTSTART:${formatICalDateTimeUTC(startDate)}`);
-			lines.push(`DTEND:${formatICalDateTimeUTC(endDate)}`);
-			lines.push(`SUMMARY:${title}`);
-			if (description) {
-				lines.push(`DESCRIPTION:${description}`);
-			}
-			if (location) {
-				lines.push(`LOCATION:${location}`);
-			}
-			lines.push("END:VEVENT");
-		}
-
-		lines.push("END:VCALENDAR");
-		return lines.join("\r\n");
-	}
-
-	// Fallback: no scheduled blocks — export the meeting availability window.
-	// "days" type meetings use anchor dates (Jan 1-7, 2023) which are not real dates.
-	if (meetingData.meetingType === "days") {
-		lines.push("END:VCALENDAR");
-		return lines.join("\r\n");
-	}
-
-	for (const dateStr of meetingData.dates) {
-		const datePart = dateStr.substring(0, 10);
-		const [hours, minutes, seconds = "00"] = meetingData.fromTime.split(":");
-		const startDate = new Date(`${datePart}T${hours}:${minutes}:${seconds}Z`);
-
-		const [eh, em, es = "00"] = meetingData.toTime.split(":");
-		const endDate = new Date(`${datePart}T${eh}:${em}:${es}Z`);
-
-		// Handle midnight UTC wraparound
-		if (endDate.getTime() <= startDate.getTime()) {
-			endDate.setUTCDate(endDate.getUTCDate() + 1);
-		}
-
-		const uid = `${meetingData.id}-${datePart}@zotmeet`;
+		const datePart = interval.date.toISOString().split("T")[0];
+		const uid = `${meetingData.id}-scheduled-${datePart}-${i}@zotmeet`;
 
 		lines.push("BEGIN:VEVENT");
 		lines.push(`UID:${uid}`);
@@ -173,6 +132,9 @@ export function downloadICalFile(
 	scheduledBlocks: SelectScheduledMeeting[] = [],
 ): void {
 	const icalContent = generateICalString(meetingData, scheduledBlocks);
+
+	if (!icalContent) return;
+
 	const blob = new Blob([icalContent], {
 		type: "text/calendar;charset=utf-8",
 	});

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -1,3 +1,4 @@
+import { fromZonedTime } from "date-fns-tz";
 import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 import {
 	getCurrentWeekDateForAnchor,
@@ -67,14 +68,27 @@ function mergeScheduledBlocks(
 	return intervals;
 }
 
-function localDateTimeToDate(date: Date, time: string): Date {
-	const parts = time.split(":").map(Number);
-	const h = parts[0];
-	const m = parts[1];
-	const s = parts[2] ?? 0;
-	const d = new Date(date);
-	d.setHours(h, m, s, 0);
-	return d;
+// Helper function to pad a number to 2 digits
+function pad2(n: number): string {
+	return String(n).padStart(2, "0");
+}
+
+function getYmd(date: Date): { yyyy: number; mm: string; dd: string } {
+	return {
+		yyyy: date.getFullYear(),
+		mm: pad2(date.getMonth() + 1),
+		dd: pad2(date.getDate()),
+	};
+}
+
+function zonedLocalDateTimeToUTCDate(
+	date: Date,
+	time: string,
+	timezone: string,
+): Date {
+	const [h, m, s = "00"] = time.split(":");
+	const { yyyy, mm, dd } = getYmd(date);
+	return fromZonedTime(`${yyyy}-${mm}-${dd}T${h}:${m}:${s}`, timezone);
 }
 
 export function generateICalString(
@@ -112,10 +126,19 @@ export function generateICalString(
 			? getCurrentWeekDateForAnchor(interval.date)
 			: interval.date;
 
-		const startDate = localDateTimeToDate(eventDate, interval.from);
-		const endDate = localDateTimeToDate(eventDate, interval.to);
+		const startDate = zonedLocalDateTimeToUTCDate(
+			eventDate,
+			interval.from,
+			meetingData.timezone,
+		);
+		const endDate = zonedLocalDateTimeToUTCDate(
+			eventDate,
+			interval.to,
+			meetingData.timezone,
+		);
 
-		const datePart = eventDate.toISOString().split("T")[0];
+		const { yyyy, mm, dd } = getYmd(eventDate);
+		const datePart = `${yyyy}-${mm}-${dd}`;
 		const uid = `${meetingData.id}-scheduled-${datePart}-${i}@zotmeet`;
 
 		lines.push("BEGIN:VEVENT");

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -75,9 +75,9 @@ function pad2(n: number): string {
 
 function getYmd(date: Date): { yyyy: number; mm: string; dd: string } {
 	return {
-		yyyy: date.getUTCFullYear(),
-		mm: pad2(date.getUTCMonth() + 1),
-		dd: pad2(date.getUTCDate()),
+		yyyy: date.getFullYear(),
+		mm: pad2(date.getMonth() + 1),
+		dd: pad2(date.getDate()),
 	};
 }
 

--- a/src/server/actions/availability/ical/action.ts
+++ b/src/server/actions/availability/ical/action.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import {
+	getExistingMeeting,
+	getScheduledTimeBlocks,
+} from "@data/meeting/queries";
+import { generateICalString } from "@/lib/ical";
+
+export async function getICalFileContent(meetingId: string) {
+	const meetingData = await getExistingMeeting(meetingId);
+	const blocks = await getScheduledTimeBlocks(meetingId);
+
+	const icalContent = generateICalString(meetingData, blocks);
+
+	return {
+		success: icalContent !== null,
+		content: icalContent,
+		filename: `${meetingData.title.replace(/[^a-zA-Z0-9]/g, "_")}.ics`,
+	};
+}

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -17,9 +17,9 @@ import {
 function combineDateAndTimeISO(date: Date, time: string): string {
 	const [hours, minutes, seconds = "00"] = time.split(":");
 
-	const yyyy = date.getUTCFullYear();
-	const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
-	const dd = String(date.getUTCDate()).padStart(2, "0");
+	const yyyy = date.getFullYear();
+	const mm = String(date.getMonth() + 1).padStart(2, "0");
+	const dd = String(date.getDate()).padStart(2, "0");
 
 	const hh = String(hours).padStart(2, "0");
 	const min = String(minutes).padStart(2, "0");

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { getScheduledTimeBlocks } from "@data/meeting/queries";
+import { mergeContiguousTimeBlocks } from "@/lib/meetings/utils";
+
+function combineDateAndTimeISO(date: Date, time: string): string {
+	const [hours, minutes, seconds = "00"] = time.split(":");
+
+	const yyyy = date.getFullYear();
+	const mm = String(date.getMonth() + 1).padStart(2, "0");
+	const dd = String(date.getDate()).padStart(2, "0");
+
+	const hh = String(hours).padStart(2, "0");
+	const min = String(minutes).padStart(2, "0");
+	const ss = String(seconds).padStart(2, "0");
+
+	return `${yyyy}-${mm}-${dd}T${hh}:${min}:${ss}`;
+}
+
+export async function getOutlookCalendarLink({
+	meetingId,
+	meetingTitle,
+	meetingDescription,
+	meetingLocation,
+}: {
+	meetingId: string;
+	meetingTitle: string;
+	meetingDescription: string | null;
+	meetingLocation: string | null;
+}) {
+	const blocks = await getScheduledTimeBlocks(meetingId);
+
+	if (!blocks.length) {
+		return {
+			success: false,
+			link: null,
+		};
+	}
+
+	const mergedInterval = mergeContiguousTimeBlocks(blocks);
+	if (!mergedInterval) {
+		return {
+			success: false,
+			link: null,
+		};
+	}
+
+	const date = blocks[0].scheduledDate;
+	const start = combineDateAndTimeISO(date, mergedInterval.from);
+	const end = combineDateAndTimeISO(date, mergedInterval.to);
+
+	const params = new URLSearchParams({
+		rru: "addevent",
+		path: "/calendar/action/compose",
+		subject: meetingTitle,
+		startdt: start,
+		enddt: end,
+		body: meetingDescription ?? "Meeting scheduled via ZotMeet.",
+		location: meetingLocation ?? "",
+	});
+
+	const link = `https://outlook.live.com/calendar/0/action/compose?${params.toString()}`;
+
+	return {
+		success: true,
+		link,
+	};
+}

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -1,10 +1,17 @@
 "use server";
 
-import { getScheduledTimeBlocks } from "@data/meeting/queries";
+import {
+	getExistingMeeting,
+	getScheduledTimeBlocks,
+} from "@data/meeting/queries";
 import {
 	groupScheduledBlocksByDate,
 	mergeContiguousTimeBlocks,
 } from "@/lib/meetings/utils";
+import {
+	getCurrentWeekDateForAnchor,
+	isAnchorDateMeeting,
+} from "@/lib/types/chrono";
 
 function combineDateAndTimeISO(date: Date, time: string): string {
 	const [hours, minutes, seconds = "00"] = time.split(":");
@@ -40,6 +47,9 @@ export async function getOutlookCalendarLink({
 		};
 	}
 
+	const meetingData = await getExistingMeeting(meetingId);
+	const isDaysOfWeek = isAnchorDateMeeting(meetingData.dates);
+
 	// Group by date, then merge each day's blocks independently
 	const grouped = groupScheduledBlocksByDate(blocks);
 
@@ -53,7 +63,9 @@ export async function getOutlookCalendarLink({
 		};
 	}
 
-	const date = firstDay.date;
+	const date = isDaysOfWeek
+		? getCurrentWeekDateForAnchor(firstDay.date)
+		: firstDay.date;
 	const start = combineDateAndTimeISO(date, mergedInterval.from);
 	const end = combineDateAndTimeISO(date, mergedInterval.to);
 

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -17,9 +17,9 @@ import {
 function combineDateAndTimeISO(date: Date, time: string): string {
 	const [hours, minutes, seconds = "00"] = time.split(":");
 
-	const yyyy = date.getFullYear();
-	const mm = String(date.getMonth() + 1).padStart(2, "0");
-	const dd = String(date.getDate()).padStart(2, "0");
+	const yyyy = date.getUTCFullYear();
+	const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+	const dd = String(date.getUTCDate()).padStart(2, "0");
 
 	const hh = String(hours).padStart(2, "0");
 	const min = String(minutes).padStart(2, "0");

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -4,6 +4,7 @@ import {
 	getExistingMeeting,
 	getScheduledTimeBlocks,
 } from "@data/meeting/queries";
+import { fromZonedTime } from "date-fns-tz";
 import {
 	groupScheduledBlocksByDate,
 	mergeContiguousTimeBlocks,
@@ -25,6 +26,11 @@ function combineDateAndTimeISO(date: Date, time: string): string {
 	const ss = String(seconds).padStart(2, "0");
 
 	return `${yyyy}-${mm}-${dd}T${hh}:${min}:${ss}`;
+}
+
+function formatOutlookDateTimeUTC(date: Date): string {
+	// Outlook accepts ISO 8601. Use explicit UTC ("Z") to avoid local-tz interpretation.
+	return date.toISOString().replace(".000Z", "Z");
 }
 
 export async function getOutlookCalendarLink({
@@ -66,8 +72,19 @@ export async function getOutlookCalendarLink({
 	const date = isDaysOfWeek
 		? getCurrentWeekDateForAnchor(firstDay.date)
 		: firstDay.date;
-	const start = combineDateAndTimeISO(date, mergedInterval.from);
-	const end = combineDateAndTimeISO(date, mergedInterval.to);
+
+	const start = formatOutlookDateTimeUTC(
+		fromZonedTime(
+			combineDateAndTimeISO(date, mergedInterval.from),
+			meetingData.timezone,
+		),
+	);
+	const end = formatOutlookDateTimeUTC(
+		fromZonedTime(
+			combineDateAndTimeISO(date, mergedInterval.to),
+			meetingData.timezone,
+		),
+	);
 
 	const params = new URLSearchParams({
 		rru: "addevent",

--- a/src/server/actions/availability/outlook/action.ts
+++ b/src/server/actions/availability/outlook/action.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { getScheduledTimeBlocks } from "@data/meeting/queries";
-import { mergeContiguousTimeBlocks } from "@/lib/meetings/utils";
+import {
+	groupScheduledBlocksByDate,
+	mergeContiguousTimeBlocks,
+} from "@/lib/meetings/utils";
 
 function combineDateAndTimeISO(date: Date, time: string): string {
 	const [hours, minutes, seconds = "00"] = time.split(":");
@@ -37,7 +40,12 @@ export async function getOutlookCalendarLink({
 		};
 	}
 
-	const mergedInterval = mergeContiguousTimeBlocks(blocks);
+	// Group by date, then merge each day's blocks independently
+	const grouped = groupScheduledBlocksByDate(blocks);
+
+	// Use the first day's merged interval for the Outlook event
+	const firstDay = grouped[0];
+	const mergedInterval = mergeContiguousTimeBlocks(firstDay.blocks);
 	if (!mergedInterval) {
 		return {
 			success: false,
@@ -45,7 +53,7 @@ export async function getOutlookCalendarLink({
 		};
 	}
 
-	const date = blocks[0].scheduledDate;
+	const date = firstDay.date;
 	const start = combineDateAndTimeISO(date, mergedInterval.from);
 	const end = combineDateAndTimeISO(date, mergedInterval.to);
 
@@ -64,5 +72,6 @@ export async function getOutlookCalendarLink({
 	return {
 		success: true,
 		link,
+		totalDays: grouped.length,
 	};
 }


### PR DESCRIPTION
## Description
This PR adds two features

- [x]  Download iCal 
- [x]  Add to Outlook

These features are only accessible if a meeting is scheduled, similarly to how the Google Calendar button works.
Works for both days of the week meeting as well as normal meetings
Note: Similarly to Google Calendar, we can only add a contiguous time block for 1 day. Therefore, when meetings on multiple days are scheduled, adding to Outlook only adds the first day, with a popup that lets the user know that if they want multiple days, they should export through the iCal feature

## Recording/Screenshots

### Before

### After

## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #311 

<!-- ## Future Follow-Up -->
