### PR TITLE
fix: 🐛 uncomment db:migration for deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # - name: Migrate database
-      #  run: pnpm db:migrate
+      - name: Migrate database
+        run: pnpm db:migrate
 
       # TODO (@KevinWu098): Remove this stage once SST fixes compat with Pulumi
       # https://github.com/anomalyco/sst/issues/6314


### PR DESCRIPTION
## Description

Generating a group invite link works only in localhost and staging. 

Uncommenting the db migration commands should allow a working share link to be generated upon deployment


## Test Plan

Click the **Share** button on any group. A link should be copied to the clipboard and other users should be able to join


