### PR TITLE
fix: 🐛 gcal button no longer shows up when users click save right after clicking "Schedule Meeting"

### DIFF
--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -167,9 +167,11 @@ export function AvailabilityHeader({
 				});
 			}
 
-			// Move pending to scheduled after successful save
-			commitPendingTimes();
-			setIsScheduled(true);
+			if (pendingAdds.size > 0 || pendingRemovals.size > 0) {
+				// Move pending to scheduled after successful save
+				commitPendingTimes();
+				setIsScheduled(true);
+			}
 			setAvailabilityView("group");
 		} catch (error) {
 			console.error("Failed to save meeting blocks", error);

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -170,7 +170,8 @@ export function AvailabilityHeader({
 			if (pendingAdds.size > 0 || pendingRemovals.size > 0) {
 				// Move pending to scheduled after successful save
 				commitPendingTimes();
-				setIsScheduled(true);
+				const { scheduledTimes } = useAvailabilityStore.getState();
+				setIsScheduled(scheduledTimes.size > 0);
 			}
 			setAvailabilityView("group");
 		} catch (error) {


### PR DESCRIPTION
## Description
This PR adds a check that fixes the following bug: meetings were marked as scheduled even when the user didn't select any time blocks (user opens an unscheduled meeting, clicks on schedule, and immediately clicks save).

## Recording/Screenshots

### Before
The "Add to Calendar" button appears initially after the user clicks Save. This is because the `isScheduled` boolean is set to true when the Save button is clicked (but not written to the DB since there are no selected blocks). When the page refreshes, the value from the DB is read, and the "Add to Calendar" button disappears. 

https://github.com/user-attachments/assets/2f4a7705-0831-4abe-b2c9-7561ffc633e2


### After
The "Add to Calendar" button doesn't show up anymore

https://github.com/user-attachments/assets/a2b5f5eb-8d86-4acf-ae31-b1fe788a99e9

## Test Plan
Meetings with >0 time blocks are still scheduled correctly

https://github.com/user-attachments/assets/ebfe556b-9574-4d27-b7ca-fd4b6290cbbd

<!-- What to do to make sure that the feature works? -->

## Issues
- Closes #333 

<!-- ## Future Follow-Up -->
