### PR TITLE
fix: ✨ dynamic table time header

### DIFF
--- a/src/app/studyrooms/page.tsx
+++ b/src/app/studyrooms/page.tsx
@@ -22,6 +22,7 @@ import { fetchStudyRooms } from "@/lib/rooms/get-rooms";
 import type { StudyRooms } from "@/lib/types/studyrooms";
 
 const LOCATION_OPTIONS = [
+	"Plaza Verde",
 	"Langson Library",
 	"Science Library",
 	"Multimedia Resources Center",
@@ -47,12 +48,15 @@ export default function Page() {
 	const [date, setDate] = useState<Date | null>(tomorrow);
 	const [startTime, setStartTime] = useState<Date | null>(defaultStart);
 	const [endTime, setEndTime] = useState<Date | null>(defaultEnd);
+	const [committedStart, setCommittedStart] = useState<Date | null>(
+		defaultStart,
+	);
+	const [committedEnd, setCommittedEnd] = useState<Date | null>(defaultEnd);
 	const [location, setLocation] = useState<string | null>(null);
 	const [capacityMin, setCapacityMin] = useState("");
 	const [capacityMax, setCapacityMax] = useState("");
 	const [isTechEnhanced, setIsTechEnhanced] = useState(false);
 	const [rooms, setRooms] = useState<StudyRooms["data"] | null>(null);
-	const [timeRange, setTimeRange] = useState("");
 	const [error, setError] = useState<string | null>(null);
 
 	const activeFilters = [
@@ -127,8 +131,9 @@ export default function Page() {
 				isTechEnhanced: isTechEnhanced || undefined,
 			});
 
-			setTimeRange(tr);
 			setRooms(data);
+			setCommittedStart(startTime);
+			setCommittedEnd(endTime);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "API call failed");
 		}
@@ -139,10 +144,15 @@ export default function Page() {
 		tmrw.setDate(tmrw.getDate() + 1);
 		const today = format(tmrw, "yyyy-MM-dd");
 		const defaultTr = "11:00am-5:00pm";
+		const initialCommittedStart = new Date();
+		initialCommittedStart.setHours(11, 0, 0, 0);
+		const initialCommittedEnd = new Date();
+		initialCommittedEnd.setHours(17, 0, 0, 0);
 		fetchStudyRooms({ date: today, timeRange: defaultTr })
 			.then(({ data }) => {
-				setTimeRange(defaultTr);
 				setRooms(data);
+				setCommittedStart(initialCommittedStart);
+				setCommittedEnd(initialCommittedEnd);
 			})
 			.catch((err) =>
 				setError(err instanceof Error ? err.message : "API call failed"),
@@ -173,13 +183,13 @@ export default function Page() {
 					<TimePicker
 						label="Start Time"
 						value={startTime}
-						onChange={setStartTime}
+						onAccept={setStartTime}
 						slotProps={{ textField: { fullWidth: true } }}
 					/>
 					<TimePicker
 						label="End Time"
 						value={endTime}
-						onChange={setEndTime}
+						onAccept={setEndTime}
 						slotProps={{ textField: { fullWidth: true } }}
 					/>
 				</Stack>
@@ -251,8 +261,12 @@ export default function Page() {
 				</Button>
 			</Box>
 
-			{rooms && (
-				<RoomsHeatmap rooms={rooms} startTime={startTime} endTime={endTime} />
+			{rooms && committedStart && committedEnd && (
+				<RoomsHeatmap
+					rooms={rooms}
+					startTime={committedStart}
+					endTime={committedEnd}
+				/>
 			)}
 			{rooms && (
 				<RoomResults rooms={rooms} startTime={startTime} endTime={endTime} />

--- a/src/app/studyrooms/page.tsx
+++ b/src/app/studyrooms/page.tsx
@@ -268,9 +268,14 @@ export default function Page() {
 					endTime={committedEnd}
 				/>
 			)}
-			{rooms && (
-				<RoomResults rooms={rooms} startTime={startTime} endTime={endTime} />
-			)}
+
+			{/*rooms && committedStart && committedEnd && (
+				<RoomResults
+					rooms={rooms}
+					startTime={committedStart}
+					endTime={committedEnd}
+				/>
+			)*/}
 		</LocalizationProvider>
 	);
 }

--- a/src/app/studyrooms/page.tsx
+++ b/src/app/studyrooms/page.tsx
@@ -251,7 +251,9 @@ export default function Page() {
 				</Button>
 			</Box>
 
-			{rooms && <RoomsHeatmap rooms={rooms} timeRange={timeRange} />}
+			{rooms && (
+				<RoomsHeatmap rooms={rooms} startTime={startTime} endTime={endTime} />
+			)}
 			{rooms && (
 				<RoomResults rooms={rooms} startTime={startTime} endTime={endTime} />
 			)}

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -14,7 +14,6 @@ import { cn } from "@/lib/utils";
 
 interface RoomsHeatmapProps {
 	rooms: StudyRooms["data"];
-	timeRange: string;
 	startTime: Date;
 	endTime: Date;
 }

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -12,20 +12,25 @@ import { buildTimeArray, formatISOToLocalTime } from "@/lib/rooms/utils";
 import type { StudyRooms } from "@/lib/types/studyrooms";
 import { cn } from "@/lib/utils";
 
-const slotStart = "2026-04-06T11:00:00Z"; // 11:00am UTC
-const slotEnd = "2026-04-06T17:00:00Z"; // 5:00pm UTC
-
-const timestamps = buildTimeArray(slotStart, slotEnd);
-
 interface RoomsHeatmapProps {
 	rooms: StudyRooms["data"];
 	timeRange: string;
+	startTime: Date;
+	endTime: Date;
 }
 
-export const RoomsHeatmap = ({ rooms, timeRange }: RoomsHeatmapProps) => {
+export const RoomsHeatmap = ({
+	rooms,
+	startTime,
+	endTime,
+}: RoomsHeatmapProps) => {
+	const timestamps = buildTimeArray(
+		startTime.toISOString(),
+		endTime.toISOString(),
+	);
+
 	return (
 		<div className="">
-			<p>{timeRange}</p>
 			<Table size="small" sx={{ borderCollapse: "collapse", borderSpacing: 0 }}>
 				<TableHead>
 					<TableRow>

--- a/src/lib/rooms/utils.ts
+++ b/src/lib/rooms/utils.ts
@@ -22,7 +22,7 @@ export const buildTimeArray = (
 	let current = start;
 	while (current < end) {
 		timestamps.push(formatISOToLocalTime(current.toISOString()));
-		current = new Date(current.getTime() + 15 * 60 * 1000);
+		current = new Date(current.getTime() + 30 * 60 * 1000);
 	}
 
 	return timestamps;

--- a/src/lib/rooms/utils.ts
+++ b/src/lib/rooms/utils.ts
@@ -4,7 +4,7 @@ export const formatISOToLocalTime = (isoString: string): string => {
 			hour: "numeric",
 			minute: "2-digit",
 			hour12: true,
-			timeZone: "UTC",
+			//timeZone: "UTC",
 		})
 		.toLowerCase();
 };
@@ -22,7 +22,7 @@ export const buildTimeArray = (
 	let current = start;
 	while (current < end) {
 		timestamps.push(formatISOToLocalTime(current.toISOString()));
-		current = new Date(current.getTime() + 30 * 60 * 1000);
+		current = new Date(current.getTime() + 15 * 60 * 1000);
 	}
 
 	return timestamps;


### PR DESCRIPTION
## Description

Removes hardcoded time header for the Rooms table. 

- The column headers are now hooked onto the MUI DatePicker
- Commented out old card display 
- Added Plaza Verde to **Location** filter


### After

https://github.com/user-attachments/assets/e5e98976-d3b1-460f-94f6-1eff6ec84fb0

### Before

https://github.com/user-attachments/assets/4da44f2b-af6f-40de-914f-588b6cba61b5


## Issues
If room utilizes 15 minute time blocks (ex. plaza verde), the cell should be half the size to match the start times accurately  


