### PR TITLE
fix: 🐛 slot timeranges

### DIFF
--- a/src/app/studyrooms/page.tsx
+++ b/src/app/studyrooms/page.tsx
@@ -17,7 +17,6 @@ import { format } from "date-fns";
 import { useEffect, useState } from "react";
 
 import { RoomsHeatmap } from "@/components/studyrooms/heatmap/rooms-heatmap";
-import { RoomResults } from "@/components/studyrooms/room-results";
 import { fetchStudyRooms } from "@/lib/rooms/get-rooms";
 import type { StudyRooms } from "@/lib/types/studyrooms";
 
@@ -52,6 +51,7 @@ export default function Page() {
 		defaultStart,
 	);
 	const [committedEnd, setCommittedEnd] = useState<Date | null>(defaultEnd);
+	const [committedDate, setCommittedDate] = useState<Date | null>(tomorrow);
 	const [location, setLocation] = useState<string | null>(null);
 	const [capacityMin, setCapacityMin] = useState("");
 	const [capacityMax, setCapacityMax] = useState("");
@@ -132,6 +132,7 @@ export default function Page() {
 			});
 
 			setRooms(data);
+			setCommittedDate(date);
 			setCommittedStart(startTime);
 			setCommittedEnd(endTime);
 		} catch (err) {
@@ -151,6 +152,7 @@ export default function Page() {
 		fetchStudyRooms({ date: today, timeRange: defaultTr })
 			.then(({ data }) => {
 				setRooms(data);
+				setCommittedDate(tmrw);
 				setCommittedStart(initialCommittedStart);
 				setCommittedEnd(initialCommittedEnd);
 			})
@@ -261,9 +263,10 @@ export default function Page() {
 				</Button>
 			</Box>
 
-			{rooms && committedStart && committedEnd && (
+			{rooms && committedDate && committedStart && committedEnd && (
 				<RoomsHeatmap
 					rooms={rooms}
+					searchDate={committedDate}
 					startTime={committedStart}
 					endTime={committedEnd}
 				/>

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -34,8 +34,7 @@ export const RoomsHeatmap = ({
 	const windowStart = mergeDateAndTime(searchDate, startTime);
 
 	return (
-		<div className="">
-			<p>{startTime.toISOString()}</p>
+		<div>
 			<Table size="small" sx={{ borderCollapse: "collapse", borderSpacing: 0 }}>
 				<TableHead>
 					<TableRow>

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -9,8 +9,9 @@ import {
 } from "@mui/material";
 import Link from "next/link";
 import {
-	buildTimeArray,
+	buildHalfHourIntervals,
 	formatISOToLocalTime,
+	groupSlotsIntoIntervals,
 	mergeDateAndTime,
 } from "@/lib/rooms/utils";
 import type { StudyRooms } from "@/lib/types/studyrooms";
@@ -29,11 +30,7 @@ export const RoomsHeatmap = ({
 	startTime,
 	endTime,
 }: RoomsHeatmapProps) => {
-	const timestamps = buildTimeArray(
-		startTime.toISOString(),
-		endTime.toISOString(),
-	);
-
+	const intervals = buildHalfHourIntervals(searchDate, startTime, endTime);
 	const windowStart = mergeDateAndTime(searchDate, startTime);
 
 	return (
@@ -43,63 +40,71 @@ export const RoomsHeatmap = ({
 				<TableHead>
 					<TableRow>
 						<TableCell>Rooms</TableCell>
-						{timestamps.map((t) => (
-							<TableCell key={t} align="center">
-								<p className="w-14 whitespace-nowrap">{t}</p>
+						{intervals.map((iv) => (
+							<TableCell key={iv.label} align="center">
+								<p className="w-14 whitespace-nowrap">{iv.label}</p>
 							</TableCell>
 						))}
 					</TableRow>
 				</TableHead>
 
 				<TableBody>
-					{rooms.map((room) => (
-						<TableRow key={room.id}>
-							<TableCell className="whitespace-nowrap">
-								<p>{room.location}</p>
+					{rooms.map((room) => {
+						const sorted = [...room.slots]
+							.sort(
+								(a, b) =>
+									new Date(a.start).getTime() - new Date(b.start).getTime(),
+							)
+							.filter((s) => new Date(s.start) >= windowStart);
 
-								<div className="flex items-center gap-2 text-xs">
-									<p className="text-xs">{room.name}</p>
-									<p>{room.capacity && `•  Cap: ${room.capacity}`}</p>
-								</div>
-								<p className="text-xs">{room.description?.slice(0, 50)}</p>
-							</TableCell>
+						const buckets = groupSlotsIntoIntervals(sorted, intervals);
 
-							{[...room.slots]
-								.sort(
-									(a, b) =>
-										new Date(a.start).getTime() - new Date(b.start).getTime(),
-								)
-								.filter((s) => new Date(s.start) >= windowStart)
-								.map((s) => {
-									return (
-										<TableCell
-											key={s.start}
-											className="border border-gray-300"
-											sx={{ padding: 0, height: "1px" }}
-										>
-											<ButtonBase
-												component={Link}
-												target="_blank"
-												href={s.url}
-												className={"h-full w-full"}
-											>
-												<Tooltip
-													placement="top"
-													title={`${formatISOToLocalTime(s.start)} - ${formatISOToLocalTime(s.end)}`}
+						return (
+							<TableRow key={room.id}>
+								<TableCell className="whitespace-nowrap">
+									<p>{room.location}</p>
+									<div className="flex items-center gap-2 text-xs">
+										<p className="text-xs">{room.name}</p>
+										<p>{room.capacity && `•  Cap: ${room.capacity}`}</p>
+									</div>
+									<p className="text-xs">{room.description?.slice(0, 50)}</p>
+								</TableCell>
+
+								{buckets.map((bucket) => (
+									<TableCell
+										key={bucket.intervalLabel}
+										className="border border-gray-300"
+										sx={{ padding: 0, height: "1px" }}
+									>
+										<div className="flex h-full">
+											{bucket.slots.map((s) => (
+												<ButtonBase
+													key={s.start}
+													component={Link}
+													target="_blank"
+													href={s.url}
+													className="h-full"
+													sx={{ flex: 1 }}
 												>
-													<span
-														className={cn(
-															"h-full w-full",
-															s.isAvailable ? "bg-green-300" : "bg-red-300",
-														)}
-													/>
-												</Tooltip>
-											</ButtonBase>
-										</TableCell>
-									);
-								})}
-						</TableRow>
-					))}
+													<Tooltip
+														placement="top"
+														title={`${formatISOToLocalTime(s.start)} - ${formatISOToLocalTime(s.end)}`}
+													>
+														<span
+															className={cn(
+																"h-full w-full",
+																s.isAvailable ? "bg-green-300" : "bg-red-300",
+															)}
+														/>
+													</Tooltip>
+												</ButtonBase>
+											))}
+										</div>
+									</TableCell>
+								))}
+							</TableRow>
+						);
+					})}
 				</TableBody>
 			</Table>
 		</div>

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -8,18 +8,24 @@ import {
 	Tooltip,
 } from "@mui/material";
 import Link from "next/link";
-import { buildTimeArray, formatISOToLocalTime } from "@/lib/rooms/utils";
+import {
+	buildTimeArray,
+	formatISOToLocalTime,
+	mergeDateAndTime,
+} from "@/lib/rooms/utils";
 import type { StudyRooms } from "@/lib/types/studyrooms";
 import { cn } from "@/lib/utils";
 
 interface RoomsHeatmapProps {
 	rooms: StudyRooms["data"];
+	searchDate: Date;
 	startTime: Date;
 	endTime: Date;
 }
 
 export const RoomsHeatmap = ({
 	rooms,
+	searchDate,
 	startTime,
 	endTime,
 }: RoomsHeatmapProps) => {
@@ -28,8 +34,11 @@ export const RoomsHeatmap = ({
 		endTime.toISOString(),
 	);
 
+	const windowStart = mergeDateAndTime(searchDate, startTime);
+
 	return (
 		<div className="">
+			<p>{startTime.toISOString()}</p>
 			<Table size="small" sx={{ borderCollapse: "collapse", borderSpacing: 0 }}>
 				<TableHead>
 					<TableRow>
@@ -60,6 +69,7 @@ export const RoomsHeatmap = ({
 									(a, b) =>
 										new Date(a.start).getTime() - new Date(b.start).getTime(),
 								)
+								.filter((s) => new Date(s.start) >= windowStart)
 								.map((s) => {
 									return (
 										<TableCell

--- a/src/lib/rooms/utils.ts
+++ b/src/lib/rooms/utils.ts
@@ -83,6 +83,21 @@ export function findSlotOverlappingInterval<
 	return overlapping[0];
 }
 
+/** Earliest-starting slot whose interval overlaps `[rangeStart, rangeEnd)`. */
+export function findFirstSlotOverlappingRange<
+	T extends { start: string; end: string },
+>(slots: T[], rangeStart: Date, rangeEnd: Date): T | undefined {
+	const overlapping = slots.filter((s) => {
+		const ss = new Date(s.start);
+		const se = new Date(s.end);
+		return ss < rangeEnd && se > rangeStart;
+	});
+	overlapping.sort(
+		(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+	);
+	return overlapping[0];
+}
+
 // returns an array of formatted times in 30 min intervals
 export const buildTimeArray = (
 	slotStart: string,
@@ -101,3 +116,30 @@ export const buildTimeArray = (
 
 	return timestamps;
 };
+
+export type SlotBucket<T> = {
+	intervalLabel: string;
+	intervalStart: Date;
+	slots: T[];
+};
+
+// returns an array. each SlotBucket represents a 30 minute window.
+// if a room uses 15-minute slots, two of them will fall under a single window
+export function groupSlotsIntoIntervals<
+	T extends { start: string; end: string },
+>(slots: T[], intervals: HalfHourInterval[]): SlotBucket<T>[] {
+	return intervals.map((interval) => {
+		const matching = slots.filter((s) => {
+			const ss = new Date(s.start);
+			return ss >= interval.start && ss < interval.end;
+		});
+		matching.sort(
+			(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+		);
+		return {
+			intervalLabel: interval.label,
+			intervalStart: interval.start,
+			slots: matching,
+		};
+	});
+}

--- a/src/lib/rooms/utils.ts
+++ b/src/lib/rooms/utils.ts
@@ -9,6 +9,80 @@ export const formatISOToLocalTime = (isoString: string): string => {
 		.toLowerCase();
 };
 
+const HALF_HOUR_MS = 30 * 60 * 1000;
+
+/** Calendar day + clock from `time` (same semantics as date pickers + time pickers). */
+export function mergeDateAndTime(date: Date, time: Date): Date {
+	const d = new Date(date);
+	d.setHours(
+		time.getHours(),
+		time.getMinutes(),
+		time.getSeconds(),
+		time.getMilliseconds(),
+	);
+	return d;
+}
+
+export type HalfHourInterval = { label: string; start: Date; end: Date };
+
+/** One row of labels per half-hour block between start and end on `day` (local). */
+export function buildHalfHourIntervals(
+	day: Date,
+	startTime: Date,
+	endTime: Date,
+): HalfHourInterval[] {
+	const intervals: HalfHourInterval[] = [];
+	const windowStart = mergeDateAndTime(day, startTime);
+	const windowEnd = mergeDateAndTime(day, endTime);
+
+	let current = windowStart;
+	while (current < windowEnd) {
+		const intervalEnd = new Date(
+			Math.min(current.getTime() + HALF_HOUR_MS, windowEnd.getTime()),
+		);
+		intervals.push({
+			label: formatISOToLocalTime(current.toISOString()),
+			start: new Date(current),
+			end: intervalEnd,
+		});
+		current = intervalEnd;
+	}
+	return intervals;
+}
+
+/** Slot start in [windowStart, windowEnd) — same rule as RoomResults. */
+export function isSlotStartInQueryWindow(
+	slotStartIso: string,
+	windowStart: Date,
+	windowEnd: Date,
+): boolean {
+	const t = new Date(slotStartIso);
+	return t >= windowStart && t < windowEnd;
+}
+
+export function findSlotOverlappingInterval<
+	T extends { start: string; end: string },
+>(
+	slots: T[],
+	intervalStart: Date,
+	intervalEnd: Date,
+	windowStart: Date,
+	windowEnd: Date,
+): T | undefined {
+	const candidates = slots.filter((s) =>
+		isSlotStartInQueryWindow(s.start, windowStart, windowEnd),
+	);
+	const overlapping = candidates.filter((s) => {
+		const ss = new Date(s.start);
+		const se = new Date(s.end);
+		return ss < intervalEnd && se > intervalStart;
+	});
+	overlapping.sort(
+		(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+	);
+	return overlapping[0];
+}
+
 // returns an array of formatted times in 30 min intervals
 export const buildTimeArray = (
 	slotStart: string,
@@ -22,7 +96,7 @@ export const buildTimeArray = (
 	let current = start;
 	while (current < end) {
 		timestamps.push(formatISOToLocalTime(current.toISOString()));
-		current = new Date(current.getTime() + 30 * 60 * 1000);
+		current = new Date(current.getTime() + HALF_HOUR_MS);
 	}
 
 	return timestamps;


### PR DESCRIPTION
## Description
- Study rooms that support 15-minute intervals are rendered in half-width blocks to maintain.
- All rooms will now strictly follow the start/end time search

## Backend Flow
- The heatmap builds a set of half-hour interval columns based on the search date and time, then groups each room's slots into these intervals. 
     - This means rooms that support 15-minute intervals will be grouped and rendered as halves
    
## Key Changes 

 **/rooms/utils.ts** 
- Added core utilities to build the interval grid and bucket slots 

**rooms-heatmap.tsx**
- Refactored to new interval-based approach. 
- Header columns now come from **buildHalfHourIntervals**
- Each room's slots are bucketed via **groupSlotsIntoIntervals**, then rendered as flex children within each cell 

**studyrooms/page.tsx**
- tracks search date **(committedDate)** alongside existing start/end times, and passes it to **RoomsHeatmap** as **searchDate** so heatmap can anchor intervals to correct calendar day



### After
![ScreenRecording2026-04-12at12 22 43PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d90475f7-77da-4002-b7fc-618cd22ee3cf)

### Before
![ScreenRecording2026-04-12at12 23 18PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d5deaeb9-f761-4caf-9ed1-54e452944d67)

## Test Plan

<!-- What to do to make sure that the feature works? -->


## Closes

https://github.com/icssc/ZotMeet/issues/391
https://github.com/icssc/ZotMeet/issues/387

<!-- ## Future Follow-Up -->
