### PR TITLE
fix: mobile homepage alignment

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,4 +113,10 @@
 	body {
 		@apply bg-background text-foreground;
 	}
+	input[type="time"],
+	input[type="date"],
+	input[type="datetime-local"] {
+		font-size: 1rem !important;
+		min-height: 1.4375em;
+	}
 }

--- a/src/components/creation/calendar/calendar.tsx
+++ b/src/components/creation/calendar/calendar.tsx
@@ -102,7 +102,7 @@ export function Calendar({
 		: `${monthName} ${currentYear}`;
 
 	return (
-		<div className="rounded-lg border bg-gradient-to-l from-[#00A96E0D] to-[#377CFB0D] py-6">
+		<div className="rounded-lg bg-gradient-to-l from-[#00A96E0D] to-[#377CFB0D] py-6 md:border">
 			<div className="flex flex-col items-start justify-between px-4 pb-3 md:items-center md:px-8">
 				<Tabs
 					value={meetingType}

--- a/src/components/creation/calendar/calendar.tsx
+++ b/src/components/creation/calendar/calendar.tsx
@@ -1,6 +1,6 @@
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import { IconButton, Tab, Tabs } from "@mui/material";
+import { IconButton, Tab, Tabs, Typography } from "@mui/material";
 import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
 import { CalendarBody } from "@/components/creation/calendar/calendar-body";
 import { Week } from "@/components/creation/calendar/week";
@@ -103,7 +103,7 @@ export function Calendar({
 
 	return (
 		<div className="rounded-lg bg-gradient-to-l from-[#00A96E0D] to-[#377CFB0D] py-6 md:border">
-			<div className="flex flex-col items-start justify-between px-4 pb-3 md:items-center md:px-8">
+			<div className="flex flex-col items-center justify-between px-4 pb-3 md:items-center md:px-8">
 				<Tabs
 					value={meetingType}
 					onChange={(_event: React.SyntheticEvent, value: string) => {
@@ -112,7 +112,7 @@ export function Calendar({
 					}}
 					sx={{
 						"& .MuiTab-root": {
-							fontSize: { xs: "1rem", md: "1rem" },
+							fontSize: { xs: "1.1rem", md: "1.25rem" },
 							minWidth: { xs: 120, md: 180 },
 						},
 					}}
@@ -123,15 +123,15 @@ export function Calendar({
 
 				<div className="mt-4 flex w-full items-center justify-between md:justify-start md:pl-15">
 					<div className="mt-4 flex w-full items-center pl-3 md:pl-5">
-						<h3 className="font-semibold text-lg md:text-2xl">{title}</h3>
+						<h3 className="font-semibold text-xl md:text-2xl">{title}</h3>
 
 						{/* Mobile only buttons */}
-						<div className="flex gap-2 md:hidden">
-							<IconButton onClick={decrementMonth} size="small">
-								<ChevronLeftIcon />
+						<div className="ml-auto flex gap-8 md:hidden">
+							<IconButton onClick={decrementMonth} sx={{ padding: 0 }}>
+								<ChevronLeftIcon fontSize="large" />
 							</IconButton>
-							<IconButton onClick={incrementMonth} size="small">
-								<ChevronRightIcon />
+							<IconButton onClick={incrementMonth} sx={{ padding: 0 }}>
+								<ChevronRightIcon fontSize="large" />
 							</IconButton>
 						</div>
 					</div>
@@ -151,7 +151,7 @@ export function Calendar({
 						<ChevronLeftIcon />
 					</IconButton>
 
-					<div className="w-full md:px-2">
+					<div className="mt-5 w-full md:px-2">
 						<table className="w-full table-fixed border-collapse">
 							<thead>
 								<tr>

--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -176,9 +176,9 @@ export function Creation({ user }: { user: UserProfile | null }) {
 	}, [selectedDays.length, startTime, endTime, meetingName]);
 
 	return (
-		<div className="mx-auto my-6 flex w-[calc(100%-2rem)] max-w-6xl flex-col gap-y-6 px-4 md:my-8 md:rounded-xl md:border md:border-gray-300">
+		<div className="mx-auto my-6 flex w-full max-w-6xl flex-col gap-y-6 px-0 md:my-8 md:w-[calc(100%-2rem)] md:rounded-xl md:border md:border-gray-300 md:px-4">
 			<div className="px-2 pt-2 md:pt-2 md:pl-[40px]"></div>
-			<div className="w-full px-4 py-6 md:px-14">
+			<div className="w-full px-2 py-6 md:px-14">
 				<h2 className="hidden font-medium text-2xl sm:block md:text-3xl">
 					Plan your next meeting with ZotMeet
 				</h2>
@@ -190,7 +190,7 @@ export function Creation({ user }: { user: UserProfile | null }) {
 					FIND THE PERFECT TIME AND PLACE FOR YOUR MEETING.
 				</h3>
 
-				<div className="flex w-full max-w-md flex-col gap-6 md:w-full md:max-w-none">
+				<div className="flex w-full flex-col gap-6">
 					<MeetingNameField
 						meetingName={meetingName}
 						setMeetingName={setMeetingName}

--- a/src/components/creation/fields/meeting-time-field.tsx
+++ b/src/components/creation/fields/meeting-time-field.tsx
@@ -96,6 +96,12 @@ export const MeetingTimeField = ({
 					onChange={(e) =>
 						setStartTime(`${e.target.value}:00` as HourMinuteString)
 					}
+					inputProps={{ style: { fontSize: "1rem" } }}
+					sx={(theme) => ({
+						"& input::-webkit-calendar-picker-indicator": {
+							filter: theme.palette.mode === "dark" ? "invert(1)" : "none",
+						},
+					})}
 				/>
 
 				<TextField
@@ -109,6 +115,12 @@ export const MeetingTimeField = ({
 					onChange={(e) =>
 						setEndTime(`${e.target.value}:00` as HourMinuteString)
 					}
+					inputProps={{ style: { fontSize: "1rem" } }}
+					sx={(theme) => ({
+						"& input::-webkit-calendar-picker-indicator": {
+							filter: theme.palette.mode === "dark" ? "invert(1)" : "none",
+						},
+					})}
 				/>
 				<div className="flex gap-2"></div>
 			</div>

--- a/src/components/nav/mui-bottom-nav.tsx
+++ b/src/components/nav/mui-bottom-nav.tsx
@@ -1,18 +1,13 @@
 "use client";
 
-import {
-	AddCircleOutline,
-	CalendarMonth,
-	Groups,
-	Person,
-} from "@mui/icons-material";
+import { Apartment, CalendarMonth, Groups, Person } from "@mui/icons-material";
 import { BottomNavigation, BottomNavigationAction, Paper } from "@mui/material";
 import { usePathname, useRouter } from "next/navigation";
 
 const navItems = [
-	{ label: "New", value: "/", icon: AddCircleOutline },
-	{ label: "Summary", value: "/summary", icon: CalendarMonth },
+	{ label: "Meetings", value: "/summary", icon: CalendarMonth },
 	{ label: "Groups", value: "/groups", icon: Groups },
+	{ label: "Rooms", value: "/studyrooms", icon: Apartment },
 	{ label: "Profile", value: "/profile", icon: Person },
 ];
 


### PR DESCRIPTION
## Description
Key Changes:
- Added Rooms to Navbar 
- Must Click "Create Meeting" to access / page
- Removed excess margin on homepage
- Aligned chevron month buttons


New (left) vs. Old (right)

<img width="49%" height="2532" alt="IMG_5282" src="https://github.com/user-attachments/assets/01d35cdc-aa08-4084-9c42-437e2a0c65ec" />
<img width="49%" height="2532" alt="IMG_5283" src="https://github.com/user-attachments/assets/42965c6c-f551-4be6-93bc-40e788fcb562" />


## Issues 
Once we add meetings to the homepage for desktop, we should remove access to /summary on mobile. Clicking **Create Meeting** would trigger a popup on the same page instead of redirecting to another page

