### PR TITLE
feat: ✨ redirect to google oauth for unprotected routes

### DIFF
--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -25,7 +25,7 @@ export default async function Page(props: PageProps) {
 
 	const session = await getCurrentSession();
 	if (!session?.user) {
-		redirect("/");
+		redirect("/auth/login/google");
 	}
 
 	const group = await getExistingGroup(id).catch(() => null);

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -6,7 +6,7 @@ import { getGroupsWithDetails } from "@/server/data/groups/queries";
 export default async function Page() {
 	const session = await getCurrentSession();
 	if (!session?.user) {
-		redirect("/");
+		redirect("/auth/login/google");
 	}
 
 	const memberId = session.user.memberId;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,30 +1,16 @@
-"use client";
+import { notFound, redirect } from "next/navigation";
+import { getCurrentSession } from "@/lib/auth";
+import { ProfileContent } from "./profile-content";
 
-import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
-import { useThemeMode } from "@/components/theme/theme-provider";
+export default async function ProfilePage() {
+	const session = await getCurrentSession();
+	if (!session?.user) {
+		redirect("/auth/login/google");
+	}
 
-export default function ProfilePage() {
-	const { mode, setMode } = useThemeMode();
+	if (!session.user.memberId) {
+		notFound();
+	}
 
-	return (
-		<div className="px-8 py-8">
-			<h1 className="font-figtree font-medium text-3xl">Profile</h1>
-			<div className="max-w-sm">
-				<p className="mb-2 font-medium">Preferred Display Mode</p>
-
-				<FormControl fullWidth>
-					<InputLabel id="theme-select-label">Mode</InputLabel>
-					<Select
-						labelId="theme-select-label"
-						value={mode}
-						label="Mode"
-						onChange={(e) => setMode(e.target.value as "light" | "dark")}
-					>
-						<MenuItem value="light">Light</MenuItem>
-						<MenuItem value="dark">Dark</MenuItem>
-					</Select>
-				</FormControl>
-			</div>
-		</div>
-	);
+	return <ProfileContent />;
 }

--- a/src/app/profile/profile-content.tsx
+++ b/src/app/profile/profile-content.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { useThemeMode } from "@/components/theme/theme-provider";
+
+export function ProfileContent() {
+	const { mode, setMode } = useThemeMode();
+
+	return (
+		<div className="px-8 py-8">
+			<h1 className="font-figtree font-medium text-3xl">Profile</h1>
+			<div className="max-w-sm">
+				<p className="mb-2 font-medium">Preferred Display Mode</p>
+
+				<FormControl fullWidth>
+					<InputLabel id="theme-select-label">Mode</InputLabel>
+					<Select
+						labelId="theme-select-label"
+						value={mode}
+						label="Mode"
+						onChange={(e) => setMode(e.target.value as "light" | "dark")}
+					>
+						<MenuItem value="light">Light</MenuItem>
+						<MenuItem value="dark">Dark</MenuItem>
+					</Select>
+				</FormControl>
+			</div>
+		</div>
+	);
+}

--- a/src/app/profile/profile-content.tsx
+++ b/src/app/profile/profile-content.tsx
@@ -18,10 +18,13 @@ export function ProfileContent() {
 						labelId="theme-select-label"
 						value={mode}
 						label="Mode"
-						onChange={(e) => setMode(e.target.value as "light" | "dark")}
+						onChange={(e) =>
+							setMode(e.target.value as "light" | "dark" | "system")
+						}
 					>
 						<MenuItem value="light">Light</MenuItem>
 						<MenuItem value="dark">Dark</MenuItem>
+						<MenuItem value="system">System</MenuItem>
 					</Select>
 				</FormControl>
 			</div>

--- a/src/app/summary/page.tsx
+++ b/src/app/summary/page.tsx
@@ -12,7 +12,7 @@ import {
 export default async function Page() {
 	const session = await getCurrentSession();
 	if (!session?.user) {
-		redirect("/");
+		redirect("/auth/login/google");
 	}
 
 	const memberId = session.user.memberId;


### PR DESCRIPTION
## Description
Accessing the summary, groups, and profile pages now redirects the user to Google Auth
## Recording/Screenshots

https://github.com/user-attachments/assets/494abf6a-a589-4267-86f1-bda5f20b2525


## Test Plan
Edit the URL slug to try to directly access summary, groups, or profile pages.
<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #373 

<!-- ## Future Follow-Up -->
