### PR TITLE
fix: 🐛 availability now seen on hover

### DIFF
--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -222,7 +222,13 @@ export function GroupResponses({
 										: "default"
 								}
 								variant="outlined"
-								sx={{ maxWidth: "100%" }}
+								sx={
+									isHoveringGrid
+										? availableMembers.includes(member)
+											? { maxWidth: "100%" }
+											: { textDecoration: "line-through", maxWidth: "100%" }
+										: { maxWidth: "100%" }
+								}
 								onMouseEnter={() => handleMemberHover(member.memberId)}
 								onMouseLeave={() => handleMemberHover(null)}
 								onClick={() => handleMemberSelect(member.memberId)}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -110,6 +110,7 @@ export const getTheme = (mode: "light" | "dark") =>
 			primary: {
 				main: "#F26489",
 				contrastText: "#ffffff",
+				light: "#fed3df",
 			},
 			secondary: {
 				main: "#1F2A44",


### PR DESCRIPTION
hovering over a timeslot can now strikethroughs members who cannot make it

## Description

## Recording/Screenshots
<img width="1276" height="574" alt="image" src="https://github.com/user-attachments/assets/563ba2c3-760a-4dc8-8518-be595cfa8e5e" />
<img width="1280" height="598" alt="image" src="https://github.com/user-attachments/assets/9f1d89b6-1ac7-4902-85ce-5d3f340bd33f" />

### Before

### After

## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #402

<!-- ## Future Follow-Up -->
