### PR TITLE
fix: login tab on mobile navbar

### DIFF
--- a/src/components/nav/mui-app-shell.tsx
+++ b/src/components/nav/mui-app-shell.tsx
@@ -32,7 +32,7 @@ export function MuiAppShell({
 			<Box sx={{ flex: 1, overflow: "auto", paddingBottom: isMobile ? 7 : 0 }}>
 				{children}
 			</Box>
-			{isMobile && <MuiBottomNav />}
+			{isMobile && <MuiBottomNav user={user} />}
 		</Box>
 	);
 }

--- a/src/components/nav/mui-bottom-nav.tsx
+++ b/src/components/nav/mui-bottom-nav.tsx
@@ -1,23 +1,32 @@
 "use client";
 
-import { Apartment, CalendarMonth, Groups, Person } from "@mui/icons-material";
+import {
+	Apartment,
+	CalendarMonth,
+	Groups,
+	Login,
+	Person,
+} from "@mui/icons-material";
 import { BottomNavigation, BottomNavigationAction, Paper } from "@mui/material";
 import { usePathname, useRouter } from "next/navigation";
+import type { UserProfile } from "@/lib/auth/user";
 
-const navItems = [
-	{ label: "Meetings", value: "/summary", icon: CalendarMonth },
-	{ label: "Groups", value: "/groups", icon: Groups },
-	{ label: "Rooms", value: "/studyrooms", icon: Apartment },
-	{ label: "Profile", value: "/profile", icon: Person },
-];
-
-export function MuiBottomNav() {
+export function MuiBottomNav({ user }: { user: UserProfile | null }) {
 	const pathname = usePathname();
 	const router = useRouter();
 
 	const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
 		router.push(newValue);
 	};
+
+	const navItems = [
+		{ label: "Meetings", value: "/summary", icon: CalendarMonth },
+		{ label: "Groups", value: "/groups", icon: Groups },
+		{ label: "Rooms", value: "/studyrooms", icon: Apartment },
+		user
+			? { label: "Profile", value: "/profile", icon: Person }
+			: { label: "Sign In", value: "/auth/login/google", icon: Login },
+	];
 
 	return (
 		<Paper


### PR DESCRIPTION
## Description
The profile tab on the mobile navbar changes to a "Login" tab while the user is out of session 



<img width="382" height="70" alt="image" src="https://github.com/user-attachments/assets/1815079e-1f98-4667-bda3-2cfbd9c92223" />
<img width="382" height="70" alt="image" src="https://github.com/user-attachments/assets/03d0b5ba-5e5c-4c69-b63d-406281992ae6" />




## Issues



- Closes #
https://github.com/icssc/ZotMeet/issues/404
<!-- ## Future Follow-Up -->
