### PR TITLE
fix: 🐛 render meeting name only on blur & push state down

### DIFF
--- a/src/components/availability/header/edit-modal.tsx
+++ b/src/components/availability/header/edit-modal.tsx
@@ -120,7 +120,7 @@ export const EditModal = ({
 			<DialogContent>
 				<div className="flex flex-col space-y-6 pt-2">
 					<MeetingNameField
-						initialValue={meetingData.title}
+						initialValue={meetingName}
 						onBlur={setMeetingName}
 					/>
 

--- a/src/components/availability/header/edit-modal.tsx
+++ b/src/components/availability/header/edit-modal.tsx
@@ -120,7 +120,7 @@ export const EditModal = ({
 			<DialogContent>
 				<div className="flex flex-col space-y-6 pt-2">
 					<MeetingNameField
-						initialValue={meetingName}
+						initialValue={meetingData.title}
 						onBlur={setMeetingName}
 					/>
 

--- a/src/components/availability/header/edit-modal.tsx
+++ b/src/components/availability/header/edit-modal.tsx
@@ -120,8 +120,8 @@ export const EditModal = ({
 			<DialogContent>
 				<div className="flex flex-col space-y-6 pt-2">
 					<MeetingNameField
-						meetingName={meetingName}
-						setMeetingName={setMeetingName}
+						initialValue={meetingData.title}
+						onBlur={setMeetingName}
 					/>
 
 					<MeetingTimeField

--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -53,13 +53,9 @@ export function Creation({ user }: { user: UserProfile | null }) {
 		});
 	};
 
-	const meetingName = urlState.meetingName;
-	const setMeetingName = (nameOrUpdater: React.SetStateAction<string>) => {
-		const newName =
-			typeof nameOrUpdater === "function"
-				? nameOrUpdater(urlState.meetingName)
-				: nameOrUpdater;
-		void setUrlState({ meetingName: newName });
+	const [meetingName, setMeetingName] = useState(urlState.meetingName);
+	const flushMeetingName = () => {
+		void setUrlState({ meetingName });
 	};
 
 	const meetingLocation = urlState.meetingLocation;
@@ -194,6 +190,7 @@ export function Creation({ user }: { user: UserProfile | null }) {
 					<MeetingNameField
 						meetingName={meetingName}
 						setMeetingName={setMeetingName}
+						onBlur={flushMeetingName}
 					/>
 					<div className="flex flex-col md:grid md:grid-cols-2 md:gap-8">
 						<div className="mb-4 flex flex-col gap-y-12">

--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -8,7 +8,7 @@ import {
 	parseAsStringEnum,
 	useQueryStates,
 } from "nuqs";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Calendar } from "@/components/creation/calendar/calendar";
 //import { MeetingLocationField } from "@/components/creation/fields/meeting-location-field";
 import { MeetingNameField } from "@/components/creation/fields/meeting-name-field";
@@ -53,9 +53,12 @@ export function Creation({ user }: { user: UserProfile | null }) {
 		});
 	};
 
-	const [meetingName, setMeetingName] = useState(urlState.meetingName);
-	const flushMeetingName = () => {
-		void setUrlState({ meetingName });
+	const meetingNameRef = useRef(urlState.meetingName);
+	const [hasMeetingName, setHasMeetingName] = useState(!!urlState.meetingName);
+	const flushMeetingName = (value: string) => {
+		meetingNameRef.current = value;
+		setHasMeetingName(!!value);
+		void setUrlState({ meetingName: value });
 	};
 
 	const meetingLocation = urlState.meetingLocation;
@@ -107,7 +110,7 @@ export function Creation({ user }: { user: UserProfile | null }) {
 		if (!user) {
 			// Construct URL with all parameters.
 			const params = new URLSearchParams();
-			params.set("meetingName", meetingName);
+			params.set("meetingName", meetingNameRef.current);
 			params.set("startTime", startTime);
 			params.set("endTime", endTime);
 			params.set(
@@ -142,7 +145,7 @@ export function Creation({ user }: { user: UserProfile | null }) {
 		const toTimeUTC = convertTimeToUTC(endTime, userTimezone, referenceDate);
 
 		const newMeeting = {
-			title: meetingName,
+			title: meetingNameRef.current,
 			fromTime: fromTimeUTC,
 			toTime: toTimeUTC,
 			hostId: user.memberId,
@@ -167,9 +170,9 @@ export function Creation({ user }: { user: UserProfile | null }) {
 			startTime &&
 			endTime &&
 			startTime < endTime &&
-			meetingName
+			hasMeetingName
 		);
-	}, [selectedDays.length, startTime, endTime, meetingName]);
+	}, [selectedDays.length, startTime, endTime, hasMeetingName]);
 
 	return (
 		<div className="mx-auto my-6 flex w-full max-w-6xl flex-col gap-y-6 px-0 md:my-8 md:w-[calc(100%-2rem)] md:rounded-xl md:border md:border-gray-300 md:px-4">
@@ -188,8 +191,7 @@ export function Creation({ user }: { user: UserProfile | null }) {
 
 				<div className="flex w-full flex-col gap-6">
 					<MeetingNameField
-						meetingName={meetingName}
-						setMeetingName={setMeetingName}
+						initialValue={urlState.meetingName}
 						onBlur={flushMeetingName}
 					/>
 					<div className="flex flex-col md:grid md:grid-cols-2 md:gap-8">

--- a/src/components/creation/fields/meeting-name-field.tsx
+++ b/src/components/creation/fields/meeting-name-field.tsx
@@ -5,11 +5,13 @@ import type { Dispatch, SetStateAction } from "react";
 interface MeetingNameFieldProps {
 	meetingName: string;
 	setMeetingName: Dispatch<SetStateAction<string>>;
+	onBlur?: () => void;
 }
 
 export function MeetingNameField({
 	meetingName,
 	setMeetingName,
+	onBlur,
 }: MeetingNameFieldProps) {
 	const theme = useTheme();
 	const isSmallUp = useMediaQuery(theme.breakpoints.up("sm"));
@@ -28,6 +30,7 @@ export function MeetingNameField({
 				placeholder="Enter Meeting Name"
 				value={meetingName}
 				onChange={handleChange}
+				onBlur={onBlur}
 				autoFocus
 			/>
 		</div>

--- a/src/components/creation/fields/meeting-name-field.tsx
+++ b/src/components/creation/fields/meeting-name-field.tsx
@@ -1,23 +1,22 @@
 import { TextField, useMediaQuery, useTheme } from "@mui/material";
 import type React from "react";
-import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
 
 interface MeetingNameFieldProps {
-	meetingName: string;
-	setMeetingName: Dispatch<SetStateAction<string>>;
-	onBlur?: () => void;
+	initialValue: string;
+	onBlur: (value: string) => void;
 }
 
 export function MeetingNameField({
-	meetingName,
-	setMeetingName,
+	initialValue,
 	onBlur,
 }: MeetingNameFieldProps) {
+	const [value, setValue] = useState(initialValue);
 	const theme = useTheme();
 	const isSmallUp = useMediaQuery(theme.breakpoints.up("sm"));
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setMeetingName(e.target.value);
+		setValue(e.target.value);
 	};
 
 	return (
@@ -28,9 +27,9 @@ export function MeetingNameField({
 				variant={isSmallUp ? "standard" : "outlined"}
 				size="medium"
 				placeholder="Enter Meeting Name"
-				value={meetingName}
+				value={value}
 				onChange={handleChange}
-				onBlur={onBlur}
+				onBlur={() => onBlur(value)}
 				autoFocus
 			/>
 		</div>


### PR DESCRIPTION
## Description
Previously, every edit/keystroke in the meeting name component would call nuqs' `setUrlState` which would re-render the entire page. The following changes would implement pushing the `meetingName` state down from the `Creation` component to the `MeetingNameField`, so only the input field is rendered on each keystroke, and the URL is only updated when `onBlur` is triggered. 

## Recording/Screenshots

### Before



https://github.com/user-attachments/assets/c5a23932-0ce5-47ce-841d-ea8619f19875



### After

https://github.com/user-attachments/assets/c06e7d3b-36b5-4405-b4bc-dacfbba36f41




## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #

<!-- ## Future Follow-Up -->
