### PR TITLE
feat: clear availability

### DIFF
--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -672,85 +672,142 @@ export function Availability({
 							console.log("GRAVEERROR");
 							return;
 						}
-						const ref =
-							availabilitySelectionMode === "available"
-								? availabilityDates
-								: ifNeededDates;
-						const otherRef =
-							availabilitySelectionMode === "available"
-								? ifNeededDates
-								: availabilityDates;
-						const startZotDate = ref[startBlockSelection.zotDateIndex];
-						const toggleValue = !startZotDate.getBlockAvailability(
-							startBlockSelection.blockIndex,
-						);
-						const updatedDates = ref.map((d) => d.clone());
-						const updatedOtherDates = otherRef.map((d) => d.clone());
-
-						for (
-							let dateIndex = earlierDateIndex;
-							dateIndex <= laterDateIndex;
-							dateIndex++
-						) {
-							const currentDate = updatedDates[dateIndex];
-							const otherDate = updatedOtherDates[dateIndex];
-							currentDate.setBlockAvailabilities(
-								earlierBlockIndex,
-								laterBlockIndex,
-								toggleValue,
+						if (availabilitySelectionMode === "unavailable") {
+							const updatedAvailabilityDates = availabilityDates.map((d) =>
+								d.clone(),
 							);
-							if (toggleValue && otherDate) {
-								// Clear the same range from the other array
-								otherDate.setBlockAvailabilities(
+							const updatedIfNeededDates = ifNeededDates.map((d) => d.clone());
+
+							for (
+								let dateIndex = earlierDateIndex;
+								dateIndex <= laterDateIndex;
+								dateIndex++
+							) {
+								const availableDate = updatedAvailabilityDates[dateIndex];
+								const ifNeededDate = updatedIfNeededDates[dateIndex];
+								availableDate.setBlockAvailabilities(
 									earlierBlockIndex,
 									laterBlockIndex,
 									false,
 								);
-							}
-
-							for (
-								let blockI = earlierBlockIndex;
-								blockI <= laterBlockIndex;
-								blockI++
-							) {
-								const timestamp = getTimestampFromBlockIndex(
-									blockI,
-									dateIndex,
-									fromTimeMinutes,
-									availabilityDates,
-									userTimezone,
+								ifNeededDate.setBlockAvailabilities(
+									earlierBlockIndex,
+									laterBlockIndex,
+									false,
 								);
 
-								if (!currentDate.groupAvailability[timestamp]) {
-									currentDate.groupAvailability[timestamp] = [];
-								}
-
-								if (toggleValue) {
-									if (
-										!currentDate.groupAvailability[timestamp].includes(memberId)
-									) {
-										currentDate.groupAvailability[timestamp].push(memberId);
-									}
-									if (otherDate?.groupAvailability[timestamp]) {
-										otherDate.groupAvailability[timestamp] =
-											otherDate.groupAvailability[timestamp].filter(
+								for (
+									let blockI = earlierBlockIndex;
+									blockI <= laterBlockIndex;
+									blockI++
+								) {
+									const timestamp = getTimestampFromBlockIndex(
+										blockI,
+										dateIndex,
+										fromTimeMinutes,
+										availabilityDates,
+										userTimezone,
+									);
+									if (availableDate.groupAvailability[timestamp]) {
+										availableDate.groupAvailability[timestamp] =
+											availableDate.groupAvailability[timestamp].filter(
 												(id) => id !== memberId,
 											);
 									}
-								} else {
-									currentDate.groupAvailability[timestamp] =
-										currentDate.groupAvailability[timestamp].filter(
-											(id) => id !== memberId,
-										);
+									if (ifNeededDate.groupAvailability[timestamp]) {
+										ifNeededDate.groupAvailability[timestamp] =
+											ifNeededDate.groupAvailability[timestamp].filter(
+												(id) => id !== memberId,
+											);
+									}
 								}
 							}
-						}
 
-						handleUserAvailabilityChange(updatedDates);
-						if (availabilitySelectionMode === "available") {
-							setIfNeededDates(updatedOtherDates);
+							setAvailabilityDates(updatedAvailabilityDates);
+							setIfNeededDates(updatedIfNeededDates);
 						} else {
-							setAvailabilityDates(updatedOtherDates);
+							const ref =
+								availabilitySelectionMode === "available"
+									? availabilityDates
+									: ifNeededDates;
+							const otherRef =
+								availabilitySelectionMode === "available"
+									? ifNeededDates
+									: availabilityDates;
+							const startZotDate = ref[startBlockSelection.zotDateIndex];
+							const toggleValue = !startZotDate.getBlockAvailability(
+								startBlockSelection.blockIndex,
+							);
+							const updatedDates = ref.map((d) => d.clone());
+							const updatedOtherDates = otherRef.map((d) => d.clone());
+
+							for (
+								let dateIndex = earlierDateIndex;
+								dateIndex <= laterDateIndex;
+								dateIndex++
+							) {
+								const currentDate = updatedDates[dateIndex];
+								const otherDate = updatedOtherDates[dateIndex];
+								currentDate.setBlockAvailabilities(
+									earlierBlockIndex,
+									laterBlockIndex,
+									toggleValue,
+								);
+								if (toggleValue && otherDate) {
+									// Clear the same range from the other array
+									otherDate.setBlockAvailabilities(
+										earlierBlockIndex,
+										laterBlockIndex,
+										false,
+									);
+								}
+
+								for (
+									let blockI = earlierBlockIndex;
+									blockI <= laterBlockIndex;
+									blockI++
+								) {
+									const timestamp = getTimestampFromBlockIndex(
+										blockI,
+										dateIndex,
+										fromTimeMinutes,
+										availabilityDates,
+										userTimezone,
+									);
+
+									if (!currentDate.groupAvailability[timestamp]) {
+										currentDate.groupAvailability[timestamp] = [];
+									}
+
+									if (toggleValue) {
+										if (
+											!currentDate.groupAvailability[timestamp].includes(
+												memberId,
+											)
+										) {
+											currentDate.groupAvailability[timestamp].push(memberId);
+										}
+										if (otherDate?.groupAvailability[timestamp]) {
+											otherDate.groupAvailability[timestamp] =
+												otherDate.groupAvailability[timestamp].filter(
+													(id) => id !== memberId,
+												);
+										}
+									} else {
+										currentDate.groupAvailability[timestamp] =
+											currentDate.groupAvailability[timestamp].filter(
+												(id) => id !== memberId,
+											);
+									}
+								}
+							}
+
+							handleUserAvailabilityChange(updatedDates);
+							if (availabilitySelectionMode === "available") {
+								setIfNeededDates(updatedOtherDates);
+							} else {
+								setAvailabilityDates(updatedOtherDates);
+							}
 						}
 					}
 				}

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -29,7 +29,7 @@ import {
 	generateTimeBlocks,
 	getTimeFromHourMinuteString,
 	getTimestampFromBlockIndex,
-	mergeImportedGridSlots,
+	mergeImportedPersonalGridSlots,
 } from "@/lib/availability/utils";
 import { fetchStudyRooms } from "@/lib/rooms/get-rooms";
 import { getBestTimeRanges } from "@/lib/rooms/utils";
@@ -351,22 +351,32 @@ export function Availability({
 	);
 
 	const handleImportSlotsFromMeeting = useCallback(
-		(slotIsoStrings: string[]) => {
-			if (!user?.memberId || slotIsoStrings.length === 0) return;
-			const merged = mergeImportedGridSlots(
+		({
+			meetingAvailabilities,
+			ifNeededAvailabilities,
+		}: {
+			meetingAvailabilities: string[];
+			ifNeededAvailabilities: string[];
+		}) => {
+			if (
+				!user?.memberId ||
+				(meetingAvailabilities.length === 0 &&
+					ifNeededAvailabilities.length === 0)
+			) {
+				return;
+			}
+			const merged = mergeImportedPersonalGridSlots({
 				availabilityDates,
-				slotIsoStrings,
-				user.memberId,
-			);
-			handleUserAvailabilityChange(merged);
+				ifNeededDates,
+				meetingAvailabilities,
+				ifNeededAvailabilities,
+				memberId: user.memberId,
+			});
+			setAvailabilityDates(merged.availabilityDates);
+			setIfNeededDates(merged.ifNeededDates);
 			setImportPreview(null);
 		},
-		[
-			availabilityDates,
-			user?.memberId,
-			handleUserAvailabilityChange,
-			setImportPreview,
-		],
+		[availabilityDates, ifNeededDates, user?.memberId, setImportPreview],
 	);
 
 	const handleClearPersonalAvailability = useCallback(() => {
@@ -472,10 +482,9 @@ export function Availability({
 	const lastUTCDateTime = useMemo(() => {
 		const day = new Date(availabilityDates[availabilityDates.length - 1].day);
 		const hours = Math.floor(
-			currentPageAvailability["availabilities"][0].latestTime / 60,
+			currentPageAvailability.availabilities[0].latestTime / 60,
 		);
-		const minutes =
-			currentPageAvailability["availabilities"][0].latestTime % 60;
+		const minutes = currentPageAvailability.availabilities[0].latestTime % 60;
 		day.setHours(hours, minutes, 0, 0);
 		return day;
 	}, [availabilityDates, currentPageAvailability]);

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -24,6 +24,7 @@ import type { UserProfile } from "@/lib/auth/user";
 import {
 	buildMeetingGridIsoSet,
 	buildZotDateRowsForMeetingDays,
+	clearPersonalGridSlots,
 	convertTimeFromUTC,
 	generateTimeBlocks,
 	getTimeFromHourMinuteString,
@@ -367,6 +368,19 @@ export function Availability({
 			setImportPreview,
 		],
 	);
+
+	const handleClearPersonalAvailability = useCallback(() => {
+		if (!user?.memberId) return;
+		const cleared = clearPersonalGridSlots(
+			availabilityDates,
+			ifNeededDates,
+			user.memberId,
+		);
+		setAvailabilityDates(cleared.availabilityDates);
+		setIfNeededDates(cleared.ifNeededDates);
+		setImportPreview(null);
+	}, [availabilityDates, ifNeededDates, user?.memberId, setImportPreview]);
+
 	const handleCancelEditing = useCallback(() => {
 		const originalDates = cancelEdit();
 		setAvailabilityDates(originalDates[0]);
@@ -932,6 +946,7 @@ export function Availability({
 								importGridIsoSet={importGridIsoSet}
 								canImport={Boolean(user?.memberId)}
 								onImportSlots={handleImportSlotsFromMeeting}
+								onClearAvailability={handleClearPersonalAvailability}
 							/>
 						</Paper>
 					</div>

--- a/src/components/availability/table/availability-block-cell.tsx
+++ b/src/components/availability/table/availability-block-cell.tsx
@@ -14,7 +14,7 @@ interface AvailabilityBlockCellProps {
 	isLastRow: boolean;
 	eventSegments: EventSegment[];
 	hasSpacerBefore?: boolean;
-	showImportPreview?: boolean;
+	importPreviewType?: "available" | "if-needed" | null;
 }
 
 export function AvailabilityBlockCell({
@@ -27,7 +27,7 @@ export function AvailabilityBlockCell({
 	isLastRow,
 	eventSegments,
 	hasSpacerBefore = false,
-	showImportPreview = false,
+	importPreviewType = null,
 }: AvailabilityBlockCellProps) {
 	const selectionState = useAvailabilityStore((state) => state.selectionState);
 
@@ -51,7 +51,7 @@ export function AvailabilityBlockCell({
 					zotDateIndex={zotDateIndex}
 					blockIndex={blockIndex}
 					selectionState={selectionState}
-					showImportPreview={showImportPreview}
+					importPreviewType={importPreviewType}
 				/>
 			</button>
 

--- a/src/components/availability/table/availability-block.tsx
+++ b/src/components/availability/table/availability-block.tsx
@@ -8,7 +8,7 @@ interface AvailabilityBlockProps {
 	zotDateIndex: number;
 	blockIndex: number;
 	selectionState: SelectionStateType | undefined;
-	showImportPreview?: boolean;
+	importPreviewType?: "available" | "if-needed" | null;
 }
 
 export function AvailabilityBlock({
@@ -17,7 +17,7 @@ export function AvailabilityBlock({
 	zotDateIndex,
 	blockIndex,
 	selectionState,
-	showImportPreview = false,
+	importPreviewType = null,
 }: AvailabilityBlockProps) {
 	/**
 	 * Computes the background color of a single time block cell
@@ -50,9 +50,14 @@ export function AvailabilityBlock({
 	return (
 		<div className="pointer-events-none relative block h-full w-full py-2">
 			<div className={cn("absolute inset-0", backgroundColor)} />
-			{showImportPreview && (
+			{importPreviewType && (
 				<div
-					className="absolute inset-0 border-2 border-primary/70 bg-primary/20"
+					className={cn(
+						"absolute inset-0 border-2",
+						importPreviewType === "if-needed"
+							? "border-[#006489]/70 bg-[#006489]/20"
+							: "border-primary/70 bg-primary/20",
+					)}
 					aria-hidden
 				/>
 			)}

--- a/src/components/availability/table/availability-blocks.tsx
+++ b/src/components/availability/table/availability-blocks.tsx
@@ -41,9 +41,7 @@ export function AvailabilityBlocks({
 			itemsPerPage: state.itemsPerPage,
 		})),
 	);
-	const importPreviewIsoSet = useAvailabilityStore(
-		(s) => s.importPreviewIsoSet,
-	);
+	const importPreview = useAvailabilityStore((s) => s.importPreview);
 
 	const isTopOfHour = timeBlock % 60 === 0;
 	const isHalfHour = timeBlock % 60 === 30;
@@ -80,8 +78,12 @@ export function AvailabilityBlocks({
 							availabilityDates,
 							timeZone,
 						);
-						const showImportPreview =
-							Boolean(slotIso) && Boolean(importPreviewIsoSet?.has(slotIso));
+						const importPreviewType =
+							slotIso && importPreview?.ifNeededIsoSet.has(slotIso)
+								? "if-needed"
+								: slotIso && importPreview?.availableIsoSet.has(slotIso)
+									? "available"
+									: null;
 
 						return (
 							<React.Fragment key={key}>
@@ -98,7 +100,7 @@ export function AvailabilityBlocks({
 									isLastRow={isLastRow}
 									eventSegments={segmentsForCell}
 									hasSpacerBefore={spacers[pageDateIndex]}
-									showImportPreview={showImportPreview}
+									importPreviewType={importPreviewType}
 								/>
 							</React.Fragment>
 						);

--- a/src/components/nav/personal-availability-sidebar.tsx
+++ b/src/components/nav/personal-availability-sidebar.tsx
@@ -25,6 +25,10 @@ import { useAvailabilityStore } from "@/store/useAvailabilityStore";
 import type { Availability } from "../availability/availability";
 
 type RespondedMeeting = { id: string; title: string; createdAt: Date };
+type ImportedMeetingAvailability = {
+	meetingAvailabilities: string[];
+	ifNeededAvailabilities: string[];
+};
 
 const options: { value: Availability; label: string; icon: React.ReactNode }[] =
 	[
@@ -83,7 +87,7 @@ interface PersonalAvailabilitySidebarProps {
 	setAvailability: Dispatch<SetStateAction<Availability>>;
 	importGridIsoSet: ReadonlySet<string>;
 	canImport: boolean;
-	onImportSlots: (slotIsoStrings: string[]) => void;
+	onImportSlots: (slots: ImportedMeetingAvailability) => void;
 	onClearAvailability: () => void;
 }
 
@@ -100,7 +104,9 @@ export function PersonalAvailabilitySidebar({
 	const [importableMeetings, setImportableMeetings] = useState<
 		RespondedMeeting[]
 	>([]);
-	const availabilityCache = useRef(new Map<string, string[]>());
+	const availabilityCache = useRef(
+		new Map<string, ImportedMeetingAvailability>(),
+	);
 	const setImportPreview = useAvailabilityStore((s) => s.setImportPreview);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset cached rows when switching meetings
@@ -121,14 +127,20 @@ export function PersonalAvailabilitySidebar({
 			let raw = availabilityCache.current.get(sourceMeetingId);
 			if (raw === undefined) {
 				const result = await getUserAvailabilityForMeeting(sourceMeetingId);
-				if (!result.success || !result.meetingAvailabilities?.length) {
+				if (!result.success) {
 					setImportPreview(null);
 					return;
 				}
-				raw = result.meetingAvailabilities;
+				raw = {
+					meetingAvailabilities: result.meetingAvailabilities ?? [],
+					ifNeededAvailabilities: result.ifNeededAvailabilities ?? [],
+				};
 				availabilityCache.current.set(sourceMeetingId, raw);
 			}
-			const filtered = filterTimestampsToMeetingGrid(raw, importGridIsoSet);
+			const filtered = filterTimestampsToMeetingGrid(
+				[...raw.meetingAvailabilities, ...raw.ifNeededAvailabilities],
+				importGridIsoSet,
+			);
 			setImportPreview(filtered.length ? filtered : null);
 		},
 		[importGridIsoSet, setImportPreview],
@@ -140,13 +152,31 @@ export function PersonalAvailabilitySidebar({
 			let raw = availabilityCache.current.get(sourceMeetingId);
 			if (raw === undefined) {
 				const result = await getUserAvailabilityForMeeting(sourceMeetingId);
-				if (!result.success || !result.meetingAvailabilities?.length) return;
-				raw = result.meetingAvailabilities;
+				if (!result.success) return;
+				raw = {
+					meetingAvailabilities: result.meetingAvailabilities ?? [],
+					ifNeededAvailabilities: result.ifNeededAvailabilities ?? [],
+				};
 				availabilityCache.current.set(sourceMeetingId, raw);
 			}
-			const filtered = filterTimestampsToMeetingGrid(raw, importGridIsoSet);
-			if (filtered.length === 0) return;
-			onImportSlots(filtered);
+			const filteredMeetingAvailabilities = filterTimestampsToMeetingGrid(
+				raw.meetingAvailabilities,
+				importGridIsoSet,
+			);
+			const filteredIfNeededAvailabilities = filterTimestampsToMeetingGrid(
+				raw.ifNeededAvailabilities,
+				importGridIsoSet,
+			);
+			if (
+				filteredMeetingAvailabilities.length === 0 &&
+				filteredIfNeededAvailabilities.length === 0
+			) {
+				return;
+			}
+			onImportSlots({
+				meetingAvailabilities: filteredMeetingAvailabilities,
+				ifNeededAvailabilities: filteredIfNeededAvailabilities,
+			});
 		},
 		[canImport, importGridIsoSet, onImportSlots],
 	);

--- a/src/components/nav/personal-availability-sidebar.tsx
+++ b/src/components/nav/personal-availability-sidebar.tsx
@@ -84,6 +84,7 @@ interface PersonalAvailabilitySidebarProps {
 	importGridIsoSet: ReadonlySet<string>;
 	canImport: boolean;
 	onImportSlots: (slotIsoStrings: string[]) => void;
+	onClearAvailability: () => void;
 }
 
 export function PersonalAvailabilitySidebar({
@@ -92,6 +93,7 @@ export function PersonalAvailabilitySidebar({
 	importGridIsoSet,
 	canImport,
 	onImportSlots,
+	onClearAvailability,
 	availability,
 	setAvailability,
 }: PersonalAvailabilitySidebarProps) {
@@ -199,7 +201,13 @@ export function PersonalAvailabilitySidebar({
 					))}
 				</ToggleButtonGroup>
 
-				<Button variant="outlined" color="inherit" fullWidth>
+				<Button
+					variant="outlined"
+					color="inherit"
+					fullWidth
+					disabled={!canImport}
+					onClick={onClearAvailability}
+				>
 					Clear availability
 				</Button>
 

--- a/src/components/nav/personal-availability-sidebar.tsx
+++ b/src/components/nav/personal-availability-sidebar.tsx
@@ -141,7 +141,20 @@ export function PersonalAvailabilitySidebar({
 				[...raw.meetingAvailabilities, ...raw.ifNeededAvailabilities],
 				importGridIsoSet,
 			);
-			setImportPreview(filtered.length ? filtered : null);
+			if (filtered.length === 0) {
+				setImportPreview(null);
+				return;
+			}
+			setImportPreview({
+				availableIsoStrings: filterTimestampsToMeetingGrid(
+					raw.meetingAvailabilities,
+					importGridIsoSet,
+				),
+				ifNeededIsoStrings: filterTimestampsToMeetingGrid(
+					raw.ifNeededAvailabilities,
+					importGridIsoSet,
+				),
+			});
 		},
 		[importGridIsoSet, setImportPreview],
 	);

--- a/src/lib/availability/utils.ts
+++ b/src/lib/availability/utils.ts
@@ -356,6 +356,80 @@ export function mergeImportedGridSlots(
 	return updated;
 }
 
+/** Merges imported available + if-needed slots while keeping states mutually exclusive. */
+export function mergeImportedPersonalGridSlots({
+	availabilityDates,
+	ifNeededDates,
+	meetingAvailabilities,
+	ifNeededAvailabilities,
+	memberId,
+}: {
+	availabilityDates: readonly ZotDate[];
+	ifNeededDates: readonly ZotDate[];
+	meetingAvailabilities: readonly string[];
+	ifNeededAvailabilities: readonly string[];
+	memberId: string;
+}): { availabilityDates: ZotDate[]; ifNeededDates: ZotDate[] } {
+	const mergedAvailabilityDates = mergeImportedGridSlots(
+		availabilityDates,
+		meetingAvailabilities,
+		memberId,
+	);
+	const mergedIfNeededDates = mergeImportedGridSlots(
+		ifNeededDates,
+		ifNeededAvailabilities,
+		memberId,
+	);
+
+	const availableSet = new Set(meetingAvailabilities);
+	const ifNeededSet = new Set(ifNeededAvailabilities);
+
+	for (
+		let dateIndex = 0;
+		dateIndex < mergedAvailabilityDates.length;
+		dateIndex++
+	) {
+		const availableDate = mergedAvailabilityDates[dateIndex];
+		const ifNeededDate = mergedIfNeededDates[dateIndex];
+		if (!availableDate || !ifNeededDate) continue;
+
+		for (const timestamp of availableSet) {
+			if (ifNeededSet.has(timestamp)) continue;
+			if (ifNeededDate.availability.includes(timestamp)) {
+				ifNeededDate.availability = ifNeededDate.availability.filter(
+					(ts) => ts !== timestamp,
+				);
+			}
+			if (ifNeededDate.groupAvailability[timestamp]) {
+				ifNeededDate.groupAvailability[timestamp] =
+					ifNeededDate.groupAvailability[timestamp].filter(
+						(id) => id !== memberId,
+					);
+			}
+		}
+
+		for (const timestamp of ifNeededSet) {
+			if (availableSet.has(timestamp)) continue;
+			if (availableDate.availability.includes(timestamp)) {
+				availableDate.availability = availableDate.availability.filter(
+					(ts) => ts !== timestamp,
+				);
+			}
+			if (availableDate.groupAvailability[timestamp]) {
+				availableDate.groupAvailability[timestamp] =
+					availableDate.groupAvailability[timestamp].filter(
+						(id) => id !== memberId,
+					);
+			}
+		}
+	}
+
+	return {
+		availabilityDates: mergedAvailabilityDates,
+		ifNeededDates: mergedIfNeededDates,
+	};
+}
+
 /** Clears personal available/if-needed slots */
 export function clearPersonalGridSlots(
 	availabilityDates: readonly ZotDate[],

--- a/src/lib/availability/utils.ts
+++ b/src/lib/availability/utils.ts
@@ -355,3 +355,30 @@ export function mergeImportedGridSlots(
 	}
 	return updated;
 }
+
+/** Clears personal available/if-needed slots */
+export function clearPersonalGridSlots(
+	availabilityDates: readonly ZotDate[],
+	ifNeededDates: readonly ZotDate[],
+	memberId: string,
+): { availabilityDates: ZotDate[]; ifNeededDates: ZotDate[] } {
+	const clearDates = (dates: readonly ZotDate[]) =>
+		dates.map((date) => {
+			const clonedDate = date.clone();
+			clonedDate.availability = [];
+			clonedDate.groupAvailability = Object.fromEntries(
+				Object.entries(clonedDate.groupAvailability).map(
+					([timestamp, members]) => [
+						timestamp,
+						members.filter((id) => id !== memberId),
+					],
+				),
+			);
+			return clonedDate;
+		});
+
+	return {
+		availabilityDates: clearDates(availabilityDates),
+		ifNeededDates: clearDates(ifNeededDates),
+	};
+}

--- a/src/server/actions/availability/copy/action.ts
+++ b/src/server/actions/availability/copy/action.ts
@@ -87,8 +87,10 @@ export async function getImportableMeetings(
 
 		const overlappingIds = new Set(
 			availabilityRows
-				.filter((row) =>
-					hasTimestampOnMeetingGrid(row.meetingAvailabilities, gridIsoSet),
+				.filter(
+					(row) =>
+						hasTimestampOnMeetingGrid(row.meetingAvailabilities, gridIsoSet) ||
+						hasTimestampOnMeetingGrid(row.ifNeededAvailabilities, gridIsoSet),
 				)
 				.map((r) => r.meetingId),
 		);
@@ -130,6 +132,7 @@ export async function getUserAvailabilityForMeeting(meetingId: string) {
 		return {
 			success: true as const,
 			meetingAvailabilities: availabilityData.meetingAvailabilities,
+			ifNeededAvailabilities: availabilityData.ifNeededAvailabilities,
 		};
 	} catch (error) {
 		console.error("Error fetching availability:", error);

--- a/src/store/useAvailabilityStore.ts
+++ b/src/store/useAvailabilityStore.ts
@@ -65,9 +65,17 @@ interface AvailabilityStore {
 	isScheduled: (timestamp: string) => boolean;
 	hydrateScheduledTimes: (timestamps: string[]) => void;
 
-	/** Personal import preview: ISO keys that exist on the current meeting grid (subset of a past meeting). */
-	importPreviewIsoSet: Set<string> | null;
-	setImportPreview: (isoStrings: readonly string[] | null) => void;
+	/** Personal import preview split by source availability type. */
+	importPreview: {
+		availableIsoSet: Set<string>;
+		ifNeededIsoSet: Set<string>;
+	} | null;
+	setImportPreview: (
+		preview: {
+			availableIsoStrings: readonly string[];
+			ifNeededIsoStrings: readonly string[];
+		} | null,
+	) => void;
 }
 
 export const useAvailabilityStore = create<AvailabilityStore>((set, get) => ({
@@ -268,9 +276,15 @@ export const useAvailabilityStore = create<AvailabilityStore>((set, get) => ({
 		});
 	},
 
-	importPreviewIsoSet: null,
-	setImportPreview: (isoStrings) =>
+	importPreview: null,
+	setImportPreview: (preview) =>
 		set({
-			importPreviewIsoSet: isoStrings === null ? null : new Set(isoStrings),
+			importPreview:
+				preview === null
+					? null
+					: {
+							availableIsoSet: new Set(preview.availableIsoStrings),
+							ifNeededIsoSet: new Set(preview.ifNeededIsoStrings),
+						},
 		}),
 }));


### PR DESCRIPTION
## Description

- Added functionality to **clear availabilities** button.

- Dragging with **unavailable** now works with "if-needed" availability blocks

- "If-Needed" blocks are now importable from previous meetings

## Recording/Screenshots

### Before

https://github.com/user-attachments/assets/2c655d3c-3fec-4d6f-b9ee-afe63082f9d2


### After

https://github.com/user-attachments/assets/74ccf849-7c0b-49bc-b542-318d5f0fc5e1

<img width="1464" height="937" alt="image" src="https://github.com/user-attachments/assets/75128af5-5c6e-413e-8683-ed9e37ff0d33" />


## Test Plan

- import availabilities with if-needed and available blocks 
- ensure that the clear availability button and the unavailable tab work as intended 
- verify that cancel and save also work as intended

## Closes 

https://github.com/icssc/ZotMeet/issues/416


