### PR TITLE
fix: 🐛 overflow on group cards

### DIFF
--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -243,7 +243,7 @@ export function GroupCard({
 							display: "flex",
 							alignItems: "center",
 							gap: "10px",
-							flexShrink: 0,
+							minWidth: 0,
 						}}
 					>
 						<Avatar
@@ -252,11 +252,20 @@ export function GroupCard({
 								height: 18,
 								fontSize: "0.625rem",
 								bgcolor: "grey.400",
+								flexShrink: 0,
 							}}
 						>
 							{creatorName[0]}
 						</Avatar>
-						<Typography variant="overline" sx={{ color: "text.secondary" }}>
+						<Typography
+							variant="overline"
+							sx={{
+								color: "text.secondary",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+								whiteSpace: "nowrap",
+							}}
+						>
 							Owned by {creatorName}
 						</Typography>
 					</Box>


### PR DESCRIPTION
## Description

Added ellipses on overflow of name for group cards. 

## Recording/Screenshots

### Before
<img width="1776" height="518" alt="image" src="https://github.com/user-attachments/assets/c5b84761-4eed-44cd-b20e-92938257f802" />

### After
<img width="1476" height="736" alt="Screenshot 2026-04-30 at 8 29 13 AM" src="https://github.com/user-attachments/assets/ae78b9e3-163c-43e9-ab74-c08d50c5563f" />

## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #

<!-- ## Future Follow-Up -->
