### PR TITLE
Ip/send notifications to nudged members

### DIFF
--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -357,6 +357,8 @@ export function Availability({
 								currentPageAvailability={currentPageAvailability}
 								availabilityTimeBlocks={availabilityTimeBlocks}
 								doesntNeedDay={doesntNeedDay}
+								meetingId={meetingData.id}
+								isOwner={!!user && meetingData.hostId === user.memberId}
 							/>
 						</Paper>
 					</div>

--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -4,13 +4,13 @@ import { XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { useSnackbar } from "@/components/ui/snackbar-provider";
-import { cloneDates } from "@/lib/availability/utils";
 import {
 	computeGroupMembersForRange,
 	type GroupMembersForRange,
 	type MemberRangeStatus,
 	statusForMember,
 } from "@/lib/availability/group-query";
+import { cloneDates } from "@/lib/availability/utils";
 import type { Member, SelectionStateType } from "@/lib/types/availability";
 import { cn } from "@/lib/utils";
 import { ZotDate } from "@/lib/zotdate";
@@ -106,10 +106,15 @@ export function GroupResponses({
 	const { showSuccess, showError } = useSnackbar();
 	const [isNudging, setIsNudging] = useState(false);
 	const [cooldownUntil, setCooldownUntil] = useState<Date | null>(null);
-	const [cooldownRemaining, setCooldownRemaining] = useState<string | null>(null);
+	const [cooldownRemaining, setCooldownRemaining] = useState<string | null>(
+		null,
+	);
 
 	useEffect(() => {
-		if (!isOwner || pendingMembers.length === 0) return;
+		if (!isOwner || pendingMembers.length === 0) {
+			setCooldownUntil(null);
+			return;
+		}
 		getNudgeCooldown(meetingId).then(({ cooldownUntil: until }) => {
 			if (until) setCooldownUntil(new Date(until));
 		});

--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -135,6 +135,8 @@ export function GroupResponses({
 			} else {
 				showError(result.message);
 			}
+		} catch {
+			showError("Failed to send nudge. Please try again.");
 		} finally {
 			setIsNudging(false);
 		}

--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -1,12 +1,18 @@
+import { NotificationsOutlined } from "@mui/icons-material";
 import { Avatar, Button, Chip, Switch, Typography } from "@mui/material/";
 import { XIcon } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
+import { useSnackbar } from "@/components/ui/snackbar-provider";
 import { computeGroupMembersForRange } from "@/lib/availability/group-query";
 import { newZonedPageAvailAndDates } from "@/lib/availability/utils";
 import type { Member, SelectionStateType } from "@/lib/types/availability";
 import { cn } from "@/lib/utils";
 import { ZotDate } from "@/lib/zotdate";
+import {
+	getNudgeCooldown,
+	nudgePendingMembers,
+} from "@/server/actions/meeting/nudge/action";
 import { useAvailabilityStore } from "@/store/useAvailabilityStore";
 
 const EN_DASH = "\u2013";
@@ -48,6 +54,13 @@ function formatRangeLabel(range: SelectionStateType, dates: ZotDate[]): string {
 	return `${dayPart}, ${startTime} ${EN_DASH} ${endTime}`;
 }
 
+function formatCooldown(ms: number): string {
+	const totalSeconds = Math.ceil(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
 interface GroupResponsesProps {
 	availabilityDates: ZotDate[];
 	members: Member[];
@@ -61,6 +74,8 @@ interface GroupResponsesProps {
 	};
 	availabilityTimeBlocks: number[];
 	doesntNeedDay: boolean;
+	meetingId: string;
+	isOwner: boolean;
 }
 
 export function GroupResponses({
@@ -71,7 +86,60 @@ export function GroupResponses({
 	timezone,
 	currentPageAvailability,
 	doesntNeedDay,
+	meetingId,
+	isOwner,
 }: GroupResponsesProps) {
+	const { showSuccess, showError } = useSnackbar();
+	const [isNudging, setIsNudging] = useState(false);
+	const [cooldownUntil, setCooldownUntil] = useState<Date | null>(null);
+	const [cooldownRemaining, setCooldownRemaining] = useState<string | null>(
+		null,
+	);
+
+	useEffect(() => {
+		if (!isOwner || pendingMembers.length === 0) return;
+		getNudgeCooldown(meetingId).then(({ cooldownUntil: until }) => {
+			if (until) setCooldownUntil(new Date(until));
+		});
+	}, [meetingId, isOwner, pendingMembers.length]);
+
+	useEffect(() => {
+		if (!cooldownUntil) {
+			setCooldownRemaining(null);
+			return;
+		}
+		const tick = () => {
+			const remaining = cooldownUntil.getTime() - Date.now();
+			if (remaining <= 0) {
+				setCooldownUntil(null);
+				setCooldownRemaining(null);
+			} else {
+				setCooldownRemaining(formatCooldown(remaining));
+			}
+		};
+		tick();
+		const id = setInterval(tick, 1000);
+		return () => clearInterval(id);
+	}, [cooldownUntil]);
+
+	const handleNudge = async () => {
+		setIsNudging(true);
+		try {
+			const result = await nudgePendingMembers(meetingId);
+			if (result.success) {
+				showSuccess(result.message);
+				setCooldownUntil(new Date(Date.now() + 45 * 60 * 1000));
+			} else if (result.cooldownUntil) {
+				setCooldownUntil(new Date(result.cooldownUntil));
+				showError(result.message);
+			} else {
+				showError(result.message);
+			}
+		} finally {
+			setIsNudging(false);
+		}
+	};
+
 	const [_newBlocks, newAvailDates] = newZonedPageAvailAndDates(
 		currentPageAvailability.availabilities,
 		availabilityDates,
@@ -271,12 +339,31 @@ export function GroupResponses({
 				</div>
 
 				<div className="flex flex-col py-2">
-					<Typography variant="h6">Pending Responders</Typography>
+					<div className="flex items-center justify-between">
+						<Typography variant="h6">Pending Responders</Typography>
+						{isOwner && pendingMembers.length > 0 && (
+							<Button
+								variant="outlined"
+								size="small"
+								startIcon={<NotificationsOutlined />}
+								disabled={isNudging || cooldownRemaining !== null}
+								onClick={handleNudge}
+							>
+								Nudge
+							</Button>
+						)}
+					</div>
+
+					{isOwner && cooldownRemaining !== null && (
+						<Typography variant="caption" sx={{ color: "error.main", mt: 0.5 }}>
+							Nudge available in {cooldownRemaining}
+						</Typography>
+					)}
 
 					{pendingMembers.length > 0 ? (
 						<div>
 							<Typography variant="caption" color="textSecondary">
-								Waiting on responses for your group ({pendingMembers.length})
+								Waiting on responses from your group ({pendingMembers.length})
 							</Typography>
 							<ul className="mt-3 flex flex-wrap gap-2">
 								{pendingMembers.map((member) => (

--- a/src/components/groups/group-member-list.tsx
+++ b/src/components/groups/group-member-list.tsx
@@ -43,6 +43,7 @@ import { copyTextToClipboard } from "@/lib/clipboard/utils";
 import { isAnchorDateString, WEEKDAYS } from "@/lib/types/chrono";
 import { createGroupInvite } from "@/server/actions/group/invite/create/action";
 import { updateMemberRole } from "@/server/actions/group/update-member-role/action";
+import { nudgePendingMembers } from "@/server/actions/meeting/nudge/action";
 import type { MeetingWithStats } from "@/server/data/groups/queries";
 import { GroupSettingsForm } from "./group-settings-form";
 
@@ -153,11 +154,13 @@ function MeetingRow({
 	status: "actionRequired" | "upcoming" | null;
 }) {
 	const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+	const [isNudging, setIsNudging] = useState(false);
+	const { showSuccess, showError } = useSnackbar();
 	const open = Boolean(anchorEl);
-	const createdByLabel =
-		meeting.hostId === currentMemberId
-			? "Created by You"
-			: `Created by ${meeting.hostName}`;
+	const isOwner = meeting.hostId === currentMemberId;
+	const createdByLabel = isOwner
+		? "Created by You"
+		: `Created by ${meeting.hostName}`;
 
 	return (
 		<div className="relative flex items-center justify-between rounded-xl border-gray-200 border-b px-4 py-4 transition-colors hover:bg-primary/5">
@@ -223,15 +226,29 @@ function MeetingRow({
 					transformOrigin={{ horizontal: "right", vertical: "top" }}
 					anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
 				>
-					<MenuItem
-						onClick={(e) => {
-							e.stopPropagation();
-							setAnchorEl(null);
-						}}
-					>
-						<People className="mr-2 size-4" />
-						Nudge Members
-					</MenuItem>
+					{isOwner && (
+						<MenuItem
+							disabled={isNudging}
+							onClick={async (e) => {
+								e.stopPropagation();
+								setAnchorEl(null);
+								setIsNudging(true);
+								try {
+									const result = await nudgePendingMembers(meeting.id);
+									if (result.success) {
+										showSuccess(result.message);
+									} else {
+										showError(result.message);
+									}
+								} finally {
+									setIsNudging(false);
+								}
+							}}
+						>
+							<People className="mr-2 size-4" />
+							Nudge Members
+						</MenuItem>
+					)}
 				</Menu>
 			</div>
 		</div>

--- a/src/components/groups/group-member-list.tsx
+++ b/src/components/groups/group-member-list.tsx
@@ -240,6 +240,8 @@ function MeetingRow({
 									} else {
 										showError(result.message);
 									}
+								} catch {
+									showError("Failed to send nudge. Please try again.");
 								} finally {
 									setIsNudging(false);
 								}

--- a/src/components/groups/group-member-list.tsx
+++ b/src/components/groups/group-member-list.tsx
@@ -210,48 +210,50 @@ function MeetingRow({
 				<p className="pointer-events-none whitespace-nowrap font-medium text-gray-400 text-xs uppercase tracking-wide">
 					{createdByLabel}
 				</p>
-				<IconButton
-					onClick={(e) => {
-						e.stopPropagation();
-						setAnchorEl(open ? null : e.currentTarget);
-					}}
-				>
-					<MoreVertical className="size-5 text-gray-500" />
-				</IconButton>
-
-				<Menu
-					anchorEl={anchorEl}
-					open={open}
-					onClose={() => setAnchorEl(null)}
-					transformOrigin={{ horizontal: "right", vertical: "top" }}
-					anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-				>
-					{isOwner && (
-						<MenuItem
-							disabled={isNudging}
-							onClick={async (e) => {
+				{isOwner && (
+					<>
+						<IconButton
+							onClick={(e) => {
 								e.stopPropagation();
-								setAnchorEl(null);
-								setIsNudging(true);
-								try {
-									const result = await nudgePendingMembers(meeting.id);
-									if (result.success) {
-										showSuccess(result.message);
-									} else {
-										showError(result.message);
-									}
-								} catch {
-									showError("Failed to send nudge. Please try again.");
-								} finally {
-									setIsNudging(false);
-								}
+								setAnchorEl(open ? null : e.currentTarget);
 							}}
 						>
-							<People className="mr-2 size-4" />
-							Nudge Members
-						</MenuItem>
-					)}
-				</Menu>
+							<MoreVertical className="size-5 text-gray-500" />
+						</IconButton>
+
+						<Menu
+							anchorEl={anchorEl}
+							open={open}
+							onClose={() => setAnchorEl(null)}
+							transformOrigin={{ horizontal: "right", vertical: "top" }}
+							anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+						>
+							<MenuItem
+								disabled={isNudging}
+								onClick={async (e) => {
+									e.stopPropagation();
+									setAnchorEl(null);
+									setIsNudging(true);
+									try {
+										const result = await nudgePendingMembers(meeting.id);
+										if (result.success) {
+											showSuccess(result.message);
+										} else {
+											showError(result.message);
+										}
+									} catch {
+										showError("Failed to send nudge. Please try again.");
+									} finally {
+										setIsNudging(false);
+									}
+								}}
+							>
+								<People className="mr-2 size-4" />
+								Nudge Members
+							</MenuItem>
+						</Menu>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/nav/mui-top-nav.tsx
+++ b/src/components/nav/mui-top-nav.tsx
@@ -265,8 +265,12 @@ function Notifications({
 											color="inherit"
 											size="small"
 											sx={{ ml: "auto", my: 2 }}
-											onClick={() => {
-												if (notif.type === "Meeting Invite") {
+											onClick={async () => {
+												await deleteNotification(notif.id);
+												if (
+													notif.type === "Meeting Invite" ||
+													notif.type === "Nudge"
+												) {
 													setAnchorEl(null);
 													router.push(notif.redirect ?? "");
 												} else {

--- a/src/server/actions/meeting/nudge/action.ts
+++ b/src/server/actions/meeting/nudge/action.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { availabilities, notifications, users } from "@/db/schema";
+import { getCurrentSession } from "@/lib/auth";
+import { createInviteEmail } from "@/lib/email/templates";
+import { getExistingMeeting } from "@/server/data/meeting/queries";
+import { createNewNotification } from "@/server/data/user/queries";
+
+const NUDGE_COOLDOWN_MS = 45 * 60 * 1000;
+
+export type NudgeState = {
+	success: boolean;
+	message: string;
+	cooldownUntil?: string;
+};
+
+export async function nudgePendingMembers(
+	meetingId: string,
+): Promise<NudgeState> {
+	const { user } = await getCurrentSession();
+	if (!user) {
+		return { success: false, message: "Not logged in." };
+	}
+
+	let meeting: Awaited<ReturnType<typeof getExistingMeeting>>;
+	try {
+		meeting = await getExistingMeeting(meetingId);
+	} catch {
+		return { success: false, message: "Meeting not found." };
+	}
+
+	if (meeting.hostId !== user.memberId) {
+		return {
+			success: false,
+			message: "Only the meeting host can nudge members.",
+		};
+	}
+
+	const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+	const meetingLink = `${baseUrl}/availability/${meetingId}`;
+
+	const [lastNudge] = await db
+		.select({ createdAt: notifications.createdAt })
+		.from(notifications)
+		.where(
+			and(
+				eq(notifications.type, "Nudge"),
+				eq(notifications.redirect, meetingLink),
+				eq(notifications.createdBy, user.id),
+			),
+		)
+		.orderBy(sql`${notifications.createdAt} DESC`)
+		.limit(1);
+
+	if (lastNudge?.createdAt) {
+		const elapsed = Date.now() - lastNudge.createdAt.getTime();
+		if (elapsed < NUDGE_COOLDOWN_MS) {
+			const cooldownUntil = new Date(
+				lastNudge.createdAt.getTime() + NUDGE_COOLDOWN_MS,
+			).toISOString();
+			return {
+				success: false,
+				message: "Nudge is on cooldown.",
+				cooldownUntil,
+			};
+		}
+	}
+
+	const pendingRows = await db
+		.select({ memberId: availabilities.memberId })
+		.from(availabilities)
+		.where(
+			and(
+				eq(availabilities.meetingId, meetingId),
+				sql`COALESCE(jsonb_array_length(${availabilities.meetingAvailabilities}), 0) = 0`,
+				sql`COALESCE(jsonb_array_length(${availabilities.ifNeededAvailabilities}), 0) = 0`,
+			),
+		);
+
+	if (pendingRows.length === 0) {
+		return { success: false, message: "No pending responders to nudge." };
+	}
+
+	const pendingMemberIds = pendingRows.map((r) => r.memberId);
+
+	const userRows = await db
+		.select({ id: users.id, memberId: users.memberId })
+		.from(users)
+		.where(sql`${users.memberId} IN ${pendingMemberIds}`);
+
+	const userIds = userRows.map((r) => r.id);
+	if (userIds.length === 0) {
+		return { success: false, message: "No registered users to nudge." };
+	}
+
+	try {
+		await createNewNotification(
+			userIds,
+			meeting.title,
+			`Reminder: Please add your availability for "${meeting.title}".`,
+			"Nudge",
+			meetingLink,
+			null,
+			user.id,
+			{
+				email: createInviteEmail({
+					title: `Reminder: Add your availability for "${meeting.title}"`,
+					message: `You haven't submitted your availability for "${meeting.title}" yet. Please add it so the group can find a time that works.`,
+					url: meetingLink,
+				}),
+			},
+		);
+
+		return { success: true, message: "Nudge sent!" };
+	} catch (error) {
+		console.error("Failed to send nudge:", error);
+		return { success: false, message: "Failed to send nudge. Try again." };
+	}
+}
+
+export async function getNudgeCooldown(
+	meetingId: string,
+): Promise<{ cooldownUntil: string | null }> {
+	const { user } = await getCurrentSession();
+	if (!user) return { cooldownUntil: null };
+
+	const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+	const meetingLink = `${baseUrl}/availability/${meetingId}`;
+
+	const [lastNudge] = await db
+		.select({ createdAt: notifications.createdAt })
+		.from(notifications)
+		.where(
+			and(
+				eq(notifications.type, "Nudge"),
+				eq(notifications.redirect, meetingLink),
+				eq(notifications.createdBy, user.id),
+			),
+		)
+		.orderBy(sql`${notifications.createdAt} DESC`)
+		.limit(1);
+
+	if (lastNudge?.createdAt) {
+		const elapsed = Date.now() - lastNudge.createdAt.getTime();
+		if (elapsed < NUDGE_COOLDOWN_MS) {
+			return {
+				cooldownUntil: new Date(
+					lastNudge.createdAt.getTime() + NUDGE_COOLDOWN_MS,
+				).toISOString(),
+			};
+		}
+	}
+
+	return { cooldownUntil: null };
+}

--- a/src/server/actions/meeting/nudge/action.ts
+++ b/src/server/actions/meeting/nudge/action.ts
@@ -9,6 +9,13 @@ import { getExistingMeeting } from "@/server/data/meeting/queries";
 import { createNewNotification } from "@/server/data/user/queries";
 
 const NUDGE_COOLDOWN_MS = 45 * 60 * 1000;
+const buildMeetingAvailabilityPath = (meetingId: string) =>
+	`/availability/${meetingId}`;
+
+function nudgeRedirectFilter(meetingId: string) {
+	const meetingPath = buildMeetingAvailabilityPath(meetingId);
+	return sql`${notifications.redirect} LIKE ${`%${meetingPath}`}`;
+}
 
 export type NudgeState = {
 	success: boolean;
@@ -38,8 +45,7 @@ export async function nudgePendingMembers(
 		};
 	}
 
-	const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-	const meetingLink = `${baseUrl}/availability/${meetingId}`;
+	const meetingPath = buildMeetingAvailabilityPath(meetingId);
 
 	const [lastNudge] = await db
 		.select({ createdAt: notifications.createdAt })
@@ -47,7 +53,7 @@ export async function nudgePendingMembers(
 		.where(
 			and(
 				eq(notifications.type, "Nudge"),
-				eq(notifications.redirect, meetingLink),
+				nudgeRedirectFilter(meetingId),
 				eq(notifications.createdBy, user.id),
 			),
 		)
@@ -101,14 +107,14 @@ export async function nudgePendingMembers(
 			meeting.title,
 			`Reminder: Please add your availability for "${meeting.title}".`,
 			"Nudge",
-			meetingLink,
+			meetingPath,
 			null,
 			user.id,
 			{
 				email: createInviteEmail({
 					title: `Reminder: Add your availability for "${meeting.title}"`,
 					message: `You haven't submitted your availability for "${meeting.title}" yet. Please add it so the group can find a time that works.`,
-					url: meetingLink,
+					url: `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}${meetingPath}`,
 				}),
 			},
 		);
@@ -126,16 +132,13 @@ export async function getNudgeCooldown(
 	const { user } = await getCurrentSession();
 	if (!user) return { cooldownUntil: null };
 
-	const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-	const meetingLink = `${baseUrl}/availability/${meetingId}`;
-
 	const [lastNudge] = await db
 		.select({ createdAt: notifications.createdAt })
 		.from(notifications)
 		.where(
 			and(
 				eq(notifications.type, "Nudge"),
-				eq(notifications.redirect, meetingLink),
+				nudgeRedirectFilter(meetingId),
 				eq(notifications.createdBy, user.id),
 			),
 		)


### PR DESCRIPTION
## Description

- [x] Added a Nudge button next to "Pending Responders" in the availability sidebar, visible only to the meeting host when there are members who haven't submitted availability
- [x] Updated functionality for the group page Nudge Members button in the meeting card menu to actually send notifications + emails to pending responders
- [x] Nudge sends both an in-app notification and an email reminder using the same pattern as meeting invites
- [x] Added a 45-minute cooldown between nudges per meeting — the sidebar shows a live countdown, and the group page shows an error snackbar if the cooldown hasn't expired
- [x] Hook nudge notifications to group admins



## Record
Host clicking nudge button
<img width="415" height="698" alt="Screenshot 2026-05-06 at 9 23 34 PM" src="https://github.com/user-attachments/assets/b306c4ee-b982-4621-9b89-b9e70d5d7a9e" />
Notif that recipient gets
<img width="404" height="238" alt="Screenshot 2026-05-06 at 9 23 55 PM" src="https://github.com/user-attachments/assets/d2b9a075-f8bc-463a-88cb-abe12b1ea62f" />

<img width="1321" height="230" alt="image" src="https://github.com/user-attachments/assets/b1106b67-025e-4ad6-9e60-677454022049" />


ing/Screenshots


## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #365 

<!-- ## Future Follow-Up -->
