### PR TITLE
fix: 🐛 incorrect meeting start/end dates

### DIFF
--- a/src/app/auth/login/google/callback/route.tsx
+++ b/src/app/auth/login/google/callback/route.tsx
@@ -8,7 +8,10 @@ import { setSessionTokenCookie } from "@/lib/auth/cookies";
 import { oauth } from "@/lib/auth/oauth";
 import { createSession, generateSessionToken } from "@/lib/auth/session";
 import { createGoogleUser, generateUsername } from "@/lib/auth/user";
-import { convertTimeToUTC } from "@/lib/availability/utils";
+import {
+	convertTimeToUTC,
+	sortMeetingIsoDatesAsc,
+} from "@/lib/availability/utils";
 import { availabilityPathWithOpenInvite } from "@/lib/meeting-open-invite";
 import { createMeetingFromData } from "@/server/actions/meeting/create/action";
 import { getUserById } from "@/server/data/user/queries";
@@ -190,7 +193,10 @@ export async function GET(request: Request): Promise<Response> {
 	const startTime = searchParams.get("startTime");
 	const endTime = searchParams.get("endTime");
 	const selectedDatesParam = searchParams.get("selectedDates");
-	const selectedDates = selectedDatesParam ? selectedDatesParam.split(",") : [];
+	const selectedDatesRaw = selectedDatesParam
+		? selectedDatesParam.split(",")
+		: [];
+	const selectedDates = sortMeetingIsoDatesAsc(selectedDatesRaw);
 	const meetingType = searchParams.get("meetingType");
 	const timezone = searchParams.get("timezone") || "America/Los_Angeles";
 

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -23,6 +23,7 @@ import {
 	generateTimeBlocks,
 	getTimeFromHourMinuteString,
 	mergeImportedPersonalGridSlots,
+	sortMeetingIsoDatesAsc,
 } from "@/lib/availability/utils";
 import type { MemberMeetingAvailability } from "@/lib/types/availability";
 import type { HourMinuteString } from "@/lib/types/chrono";
@@ -101,7 +102,10 @@ export function Availability({
 		Intl.DateTimeFormat().resolvedOptions().timeZone,
 	);
 	const [changeableTimezone, setChangeableTimezone] = useState(true);
-	const referenceDate = meetingData.dates[0];
+	const referenceDate = useMemo(
+		() => sortMeetingIsoDatesAsc(meetingData.dates)[0] ?? meetingData.dates[0],
+		[meetingData.dates],
+	);
 
 	const fromTimeLocal = useMemo(
 		() => convertTimeFromUTC(meetingData.fromTime, userTimezone, referenceDate),

--- a/src/components/availability/header/availability-header.tsx
+++ b/src/components/availability/header/availability-header.tsx
@@ -9,7 +9,7 @@ import {
 import { Button, IconButton, Paper, Typography } from "@mui/material";
 import { DeleteIcon, MoreVerticalIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { DeleteModal } from "@/components/availability/header/delete-modal";
 import { EditModal } from "@/components/availability/header/edit-modal";
@@ -20,6 +20,7 @@ import {
 	convertTimeFromUTC,
 	formatDateToUSNumeric,
 	formatTimeWithHoursAndMins,
+	sortMeetingIsoDatesAsc,
 } from "@/lib/availability/utils";
 import { copyTextToClipboard } from "@/lib/clipboard/utils";
 import { useAvailabilityStore } from "@/store/useAvailabilityStore";
@@ -66,16 +67,22 @@ export function AvailabilityHeader({
 		router.replace(pathname, { scroll: false });
 	}, [inviteQueryInUrl, pathname, router]);
 
-	const formattedStartDate = formatDateToUSNumeric(
-		new Date(meetingData.dates[0]),
+	const sortedMeetingDates = useMemo(
+		() => sortMeetingIsoDatesAsc(meetingData.dates),
+		[meetingData.dates],
 	);
-	const formattedEndDate = formatDateToUSNumeric(
-		new Date(meetingData.dates[meetingData.dates.length - 1]),
-	);
+
+	const firstMeetingDate =
+		sortedMeetingDates.at(0) ?? meetingData.dates.at(0) ?? "";
+	const lastMeetingDate =
+		sortedMeetingDates.at(-1) ?? meetingData.dates.at(-1) ?? firstMeetingDate;
+
+	const formattedStartDate = formatDateToUSNumeric(new Date(firstMeetingDate));
+	const formattedEndDate = formatDateToUSNumeric(new Date(lastMeetingDate));
 
 	const displayTimezone =
 		meetingData.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-	const referenceDate = meetingData.dates[0];
+	const referenceDate = firstMeetingDate;
 	const formattedStartTime = formatTimeWithHoursAndMins(
 		convertTimeFromUTC(meetingData.fromTime, displayTimezone, referenceDate),
 	);

--- a/src/components/availability/header/edit-modal.tsx
+++ b/src/components/availability/header/edit-modal.tsx
@@ -12,7 +12,11 @@ import { MeetingNameField } from "@/components/creation/fields/meeting-name-fiel
 import { MeetingTimeField } from "@/components/creation/fields/meeting-time-field";
 import { useSnackbar } from "@/components/ui/snackbar-provider";
 import type { SelectMeeting } from "@/db/schema";
-import { convertTimeFromUTC, convertTimeToUTC } from "@/lib/availability/utils";
+import {
+	convertTimeFromUTC,
+	convertTimeToUTC,
+	sortMeetingIsoDatesAsc,
+} from "@/lib/availability/utils";
 import type { HourMinuteString } from "@/lib/types/chrono";
 import { ZotDate } from "@/lib/zotdate";
 
@@ -31,7 +35,8 @@ export const EditModal = ({
 		() => Intl.DateTimeFormat().resolvedOptions().timeZone,
 		[],
 	);
-	const referenceDate = meetingData.dates[0];
+	const referenceDate =
+		sortMeetingIsoDatesAsc(meetingData.dates)[0] ?? meetingData.dates[0] ?? "";
 
 	const fromTimeLocal = useMemo(
 		() => convertTimeFromUTC(meetingData.fromTime, userTimezone, referenceDate),
@@ -59,7 +64,9 @@ export const EditModal = ({
 
 	const handleEditClick = async () => {
 		const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-		const dates = selectedDays.map((zotDate) => zotDate.day.toISOString());
+		const dates = sortMeetingIsoDatesAsc(
+			selectedDays.map((zotDate) => zotDate.day.toISOString()),
+		);
 
 		const referenceDate = dates[0];
 		const fromTimeUTC = convertTimeToUTC(

--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -15,7 +15,10 @@ import { MeetingNameField } from "@/components/creation/fields/meeting-name-fiel
 import { MeetingTimeField } from "@/components/creation/fields/meeting-time-field";
 import type { SelectMeeting } from "@/db/schema";
 import type { UserProfile } from "@/lib/auth/user";
-import { convertTimeToUTC } from "@/lib/availability/utils";
+import {
+	convertTimeToUTC,
+	sortMeetingIsoDatesAsc,
+} from "@/lib/availability/utils";
 import type { HourMinuteString } from "@/lib/types/chrono";
 import { ZotDate } from "@/lib/zotdate";
 
@@ -133,7 +136,9 @@ export function Creation({ user }: { user: UserProfile | null }) {
 		setIsCreating(true);
 
 		const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-		const dates = selectedDays.map((zotDate) => zotDate.day.toISOString());
+		const dates = sortMeetingIsoDatesAsc(
+			selectedDays.map((zotDate) => zotDate.day.toISOString()),
+		);
 
 		// Convert times from user's local timezone to UTC
 		const referenceDate = dates[0];

--- a/src/lib/availability/utils.ts
+++ b/src/lib/availability/utils.ts
@@ -66,6 +66,13 @@ export const convertTimeFromUTC = (
 	return formatInTimeZone(utcDate, timezone, "HH:mm:ss");
 };
 
+/** Meeting `dates` must be chronological for display and time conversion; selection order may differ. */
+export function sortMeetingIsoDatesAsc(dates: readonly string[]): string[] {
+	return [...dates].sort(
+		(a, b) => new Date(a).getTime() - new Date(b).getTime(),
+	);
+}
+
 export const BLOCK_LENGTH: number = 15;
 
 export const generateTimeBlocks = (

--- a/src/server/actions/meeting/create/action.ts
+++ b/src/server/actions/meeting/create/action.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { db } from "@/db";
 import { type InsertMeeting, meetings } from "@/db/schema";
 import { getCurrentSession } from "@/lib/auth";
+import { sortMeetingIsoDatesAsc } from "@/lib/availability/utils";
 import { availabilityPathWithOpenInvite } from "@/lib/meeting-open-invite";
 import { isUserInGroup } from "@/server/data/groups/queries";
 
@@ -18,6 +19,8 @@ export async function createMeetingFromData(
 		return { error: "Invalid meeting dates or times." };
 	}
 
+	const normalizedDates = sortMeetingIsoDatesAsc(dates);
+
 	const meeting: InsertMeeting = {
 		title,
 		description,
@@ -25,7 +28,7 @@ export async function createMeetingFromData(
 		toTime,
 		timezone,
 		hostId,
-		dates: dates,
+		dates: normalizedDates,
 		meetingType: meetingType || "dates",
 	};
 
@@ -74,6 +77,8 @@ export async function createMeeting(meetingData: InsertMeeting) {
 		return { error: "Invalid meeting dates or times." };
 	}
 
+	const normalizedDates = sortMeetingIsoDatesAsc(dates);
+
 	const meeting: InsertMeeting = {
 		title,
 		description,
@@ -81,7 +86,7 @@ export async function createMeeting(meetingData: InsertMeeting) {
 		toTime,
 		timezone,
 		hostId,
-		dates: dates,
+		dates: normalizedDates,
 		meetingType: meetingType || "dates",
 		group_id: group_id ?? null,
 	};

--- a/src/server/actions/meeting/edit/action.ts
+++ b/src/server/actions/meeting/edit/action.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { type InsertMeeting, meetings } from "@/db/schema";
 import { getCurrentSession } from "@/lib/auth";
+import { sortMeetingIsoDatesAsc } from "@/lib/availability/utils";
 
 export async function editMeeting(updatedMeeting: InsertMeeting) {
 	const { user } = await getCurrentSession();
@@ -17,6 +18,8 @@ export async function editMeeting(updatedMeeting: InsertMeeting) {
 	if (new Set(dates).size !== dates?.length) {
 		return { error: "Invalid meeting dates or times." };
 	}
+
+	const normalizedDates = sortMeetingIsoDatesAsc(dates);
 
 	if (!updatedMeeting.id) {
 		return { error: "Meeting ID is required." };
@@ -32,7 +35,7 @@ export async function editMeeting(updatedMeeting: InsertMeeting) {
 		.update(meetings)
 		.set({
 			title,
-			dates,
+			dates: normalizedDates,
 			fromTime,
 			toTime,
 			meetingType,


### PR DESCRIPTION
## Description

- System currently appends newly selected dates to selectedDays, so dates[0] and dates[-1] isn't always the start/end dates, especially when meeting dates are edited. 

- Fix: Sort days before saving

**Before**

https://github.com/user-attachments/assets/7c7a6ed7-53fa-43df-90af-e3acd7658add

**After**


https://github.com/user-attachments/assets/e5917006-de17-4071-b54d-6db81b479866



