### PR TITLE
refactor: ♻️ mobile responder list, drawer, chevrons

### DIFF
--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -442,9 +442,6 @@ export function Availability({
 							</Paper>
 						</div>
 
-						<div className="lg:hidden">
-							<GroupResponses {...groupResponsesProps} />
-						</div>
 						<div className="block sm:hidden">
 							<MobileGroupResponses
 								isOwner={isMeetingOwner}

--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -10,7 +10,6 @@ import { GroupResponses } from "@/components/availability/group-responses";
 import { AvailabilityHeader } from "@/components/availability/header/availability-header";
 import { InviteMembersDialog } from "@/components/availability/invite-members-dialog";
 import { PersonalAvailability } from "@/components/availability/personal-availability";
-import { AvailabilityNavButton } from "@/components/availability/table/availability-nav-button";
 import { AvailabilityTableHeader } from "@/components/availability/table/availability-table-header";
 import { TimeZoneDropdown } from "@/components/availability/table/availability-timezone";
 import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
@@ -360,15 +359,8 @@ export function Availability({
 				<Paper
 					component="div"
 					variant="outlined"
-					className="flex min-h-0 min-w-0 flex-1 flex-col items-start justify-between self-stretch overflow-y-auto [touch-action:pan-y] lg:mr-4 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-14 lg:[touch-action:auto]"
+					className="flex min-h-0 min-w-0 flex-1 flex-col self-stretch overflow-y-auto [touch-action:pan-y] lg:mr-4 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-14 lg:[touch-action:auto]"
 				>
-					<div className="-mt-2 translate-x-3">
-						<AvailabilityNavButton
-							direction="left"
-							handleClick={prevPage}
-							disabled={isFirstPage}
-						/>
-					</div>
 					<div className="flex flex-1 flex-col gap-4">
 						<div className="shrink-0 lg:hidden">
 							<AvailabilityActions {...actionsProps} />
@@ -378,6 +370,12 @@ export function Availability({
 								currentPageAvailability={currentPageAvailability}
 								meetingType={meetingData.meetingType}
 								doesntNeedDay={doesntNeedDay}
+								datePageNav={{
+									onPrev: prevPage,
+									onNext: () => nextPage(availabilityDates.length),
+									isFirstPage,
+									isLastPage,
+								}}
 							/>
 
 							<tbody onMouseLeave={handleMouseLeave}>
@@ -419,14 +417,6 @@ export function Availability({
 								changeableTimezone={changeableTimezone}
 							/>
 						</div>
-					</div>
-
-					<div className="-mt-2 -translate-x-9">
-						<AvailabilityNavButton
-							direction="right"
-							handleClick={() => nextPage(availabilityDates.length)}
-							disabled={isLastPage}
-						/>
 					</div>
 				</Paper>
 

--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/store/useAvailabilityStore";
 
 const EN_DASH = "\u2013";
+/** Tailwind `lg` breakpoint — keep aligned with `lg:` utilities. */
 const LG_UP_MEDIA = "(min-width: 1024px)";
 const RESPONDER_CHIP_CLASS: Record<MemberRangeStatus, string> = {
 	available: "",
@@ -100,7 +101,7 @@ type GroupResponsesPanelProps = {
 	onShowBestTimesChange: (checked: boolean) => void;
 	respondedMembers: Member[];
 	memberStatus: ReadonlyMap<string, MemberRangeStatus>;
-	selectedMembers: string[];
+	selectedMemberIds: ReadonlySet<string>;
 	onMemberHover: (memberId: string | null) => void;
 	onMemberSelect: (memberId: string) => void;
 	onClearSelected: () => void;
@@ -120,7 +121,7 @@ function GroupResponsesPanel({
 	onShowBestTimesChange,
 	respondedMembers,
 	memberStatus,
-	selectedMembers,
+	selectedMemberIds,
 	onMemberHover,
 	onMemberSelect,
 	onClearSelected,
@@ -155,8 +156,9 @@ function GroupResponsesPanel({
 						type="button"
 						className="rounded-lg border-[1px] border-slate-400 p-0.5"
 						onClick={onRequestClose}
+						aria-label="Close responders"
 					>
-						<XIcon className="text-lg text-slate-400" />
+						<XIcon className="text-lg text-slate-400" aria-hidden />
 					</button>
 				</div>
 			)}
@@ -211,9 +213,7 @@ function GroupResponsesPanel({
 								}
 								label={member.displayName}
 								color={
-									selectedMembers.includes(member.memberId)
-										? "primary"
-										: "default"
+									selectedMemberIds.has(member.memberId) ? "primary" : "default"
 								}
 								variant="outlined"
 								className={cn("max-w-full", RESPONDER_CHIP_CLASS[status])}
@@ -303,6 +303,7 @@ export function GroupResponses({
 	useEffect(() => {
 		setLayoutReady(true);
 	}, []);
+	// Default to desktop branch until mounted so SSR + first client paint match.
 	const isLg = layoutReady ? isLgQuery : true;
 
 	const { showSuccess, showError } = useSnackbar();
@@ -341,7 +342,7 @@ export function GroupResponses({
 		return () => clearInterval(id);
 	}, [cooldownUntil]);
 
-	const handleNudge = async () => {
+	const handleNudge = useCallback(async () => {
 		setIsNudging(true);
 		try {
 			const result = await nudgePendingMembers(meetingId);
@@ -359,7 +360,7 @@ export function GroupResponses({
 		} finally {
 			setIsNudging(false);
 		}
-	};
+	}, [meetingId, showError, showSuccess]);
 
 	const newAvailDates = useMemo(
 		() =>
@@ -461,33 +462,62 @@ export function GroupResponses({
 		setIsMobileDrawerOpen(false);
 	}, [setIsMobileDrawerOpen]);
 
-	const panelProps: Omit<GroupResponsesPanelProps, "variant"> = {
-		blockInfoString,
-		showBestTimes,
-		onShowBestTimesChange: setShowBestTimes,
-		respondedMembers,
-		memberStatus,
-		selectedMembers,
-		onMemberHover: handleMemberHover,
-		onMemberSelect: handleMemberSelect,
-		onClearSelected: handleClearSelected,
-		availableCount,
-		isOwner,
-		pendingMembers,
-		isNudging,
-		cooldownRemaining,
-		onNudge: () => {
-			void handleNudge();
-		},
-		onRequestClose: handleCloseMobile,
-	};
+	const onNudge = useCallback(() => {
+		void handleNudge();
+	}, [handleNudge]);
+
+	const selectedMemberIds = useMemo(
+		() => new Set(selectedMembers),
+		[selectedMembers],
+	);
+
+	const mobileSheetPaperSx = useMemo(() => ({ px: 2, py: 1 }) as const, []);
+
+	const panelProps: Omit<GroupResponsesPanelProps, "variant"> = useMemo(
+		() => ({
+			blockInfoString,
+			showBestTimes,
+			onShowBestTimesChange: setShowBestTimes,
+			respondedMembers,
+			memberStatus,
+			selectedMemberIds,
+			onMemberHover: handleMemberHover,
+			onMemberSelect: handleMemberSelect,
+			onClearSelected: handleClearSelected,
+			availableCount,
+			isOwner,
+			pendingMembers,
+			isNudging,
+			cooldownRemaining,
+			onNudge,
+			onRequestClose: handleCloseMobile,
+		}),
+		[
+			availableCount,
+			blockInfoString,
+			cooldownRemaining,
+			handleClearSelected,
+			handleCloseMobile,
+			handleMemberHover,
+			handleMemberSelect,
+			isNudging,
+			isOwner,
+			memberStatus,
+			onNudge,
+			pendingMembers,
+			respondedMembers,
+			selectedMemberIds,
+			setShowBestTimes,
+			showBestTimes,
+		],
+	);
 
 	if (!isLg) {
 		return (
 			<MuiBottomSheet
 				open={isMobileDrawerOpen}
 				onClose={handleCloseMobile}
-				paperSx={{ px: 2, py: 1 }}
+				paperSx={mobileSheetPaperSx}
 			>
 				<div data-availability-sidebar="">
 					<GroupResponsesPanel {...panelProps} variant="mobile" />

--- a/src/components/availability/group-responses.tsx
+++ b/src/components/availability/group-responses.tsx
@@ -1,8 +1,10 @@
 import { NotificationsOutlined } from "@mui/icons-material";
-import { Avatar, Button, Chip, Switch, Typography } from "@mui/material/";
+import { Avatar, Button, Chip, Switch, Typography } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
+import { MuiBottomSheet } from "@/components/ui/mui/mui-bottom-sheet";
 import { useSnackbar } from "@/components/ui/snackbar-provider";
 import {
 	computeGroupMembersForRange,
@@ -24,7 +26,7 @@ import {
 } from "@/store/useAvailabilityStore";
 
 const EN_DASH = "\u2013";
-
+const LG_UP_MEDIA = "(min-width: 1024px)";
 const RESPONDER_CHIP_CLASS: Record<MemberRangeStatus, string> = {
 	available: "",
 	"if-needed": "[&_.MuiChip-label]:italic",
@@ -91,6 +93,199 @@ interface GroupResponsesProps {
 	isOwner: boolean;
 }
 
+type GroupResponsesPanelProps = {
+	variant: "desktop" | "mobile";
+	blockInfoString: string;
+	showBestTimes: boolean;
+	onShowBestTimesChange: (checked: boolean) => void;
+	respondedMembers: Member[];
+	memberStatus: ReadonlyMap<string, MemberRangeStatus>;
+	selectedMembers: string[];
+	onMemberHover: (memberId: string | null) => void;
+	onMemberSelect: (memberId: string) => void;
+	onClearSelected: () => void;
+	availableCount: number;
+	isOwner: boolean;
+	pendingMembers: Member[];
+	isNudging: boolean;
+	cooldownRemaining: string | null;
+	onNudge: () => void;
+	onRequestClose: () => void;
+};
+
+function GroupResponsesPanel({
+	variant,
+	blockInfoString,
+	showBestTimes,
+	onShowBestTimesChange,
+	respondedMembers,
+	memberStatus,
+	selectedMembers,
+	onMemberHover,
+	onMemberSelect,
+	onClearSelected,
+	availableCount,
+	isOwner,
+	pendingMembers,
+	isNudging,
+	cooldownRemaining,
+	onNudge,
+	onRequestClose,
+}: GroupResponsesPanelProps) {
+	const isDesktop = variant === "desktop";
+
+	return (
+		<>
+			{isDesktop ? (
+				<div className="hidden pb-3 lg:block">
+					<Typography variant="h6">Attendees</Typography>
+					<Typography variant="caption" color="textSecondary">
+						{blockInfoString}
+					</Typography>
+				</div>
+			) : (
+				<div className="flex items-center justify-between py-4">
+					<div>
+						<h3 className="font-medium">Responders</h3>
+						<Typography variant="caption" color="textSecondary">
+							{blockInfoString}
+						</Typography>
+					</div>
+					<button
+						type="button"
+						className="rounded-lg border-[1px] border-slate-400 p-0.5"
+						onClick={onRequestClose}
+					>
+						<XIcon className="text-lg text-slate-400" />
+					</button>
+				</div>
+			)}
+
+			<div className="mt-3 flex flex-col">
+				<div>
+					<Typography variant="h6">Map Display</Typography>
+					<Typography variant="caption" color="textSecondary">
+						Filter how responder availability shows together on the map
+					</Typography>
+				</div>
+
+				<div className="mt-2 flex items-center gap-2">
+					<Switch
+						id="availability-best-times"
+						checked={showBestTimes}
+						onChange={(e) => onShowBestTimesChange(e.target.checked)}
+						size="medium"
+						inputProps={{ "aria-label": "Best Times" }}
+					/>
+					<label
+						htmlFor="availability-best-times"
+						className="cursor-pointer text-md"
+					>
+						Best Times
+					</label>
+				</div>
+			</div>
+
+			<div className="flex flex-col py-2">
+				<div>
+					<h2 className="font-medium text-xl">Responders</h2>
+					<Typography variant="caption" color="textSecondary">
+						Available ({availableCount})
+					</Typography>
+				</div>
+
+				<ul className="mt-3 flex flex-wrap gap-2">
+					{respondedMembers.map((member) => {
+						const status = memberStatus.get(member.memberId) ?? "available";
+						return (
+							<Chip
+								key={member.memberId}
+								clickable
+								icon={
+									<Avatar
+										alt={member.displayName}
+										src={member.profilePicture ?? undefined}
+										slotProps={{ img: { referrerPolicy: "no-referrer" } }}
+										sx={{ width: 24, height: 24, fontSize: 12 }}
+									/>
+								}
+								label={member.displayName}
+								color={
+									selectedMembers.includes(member.memberId)
+										? "primary"
+										: "default"
+								}
+								variant="outlined"
+								className={cn("max-w-full", RESPONDER_CHIP_CLASS[status])}
+								onMouseEnter={() => onMemberHover(member.memberId)}
+								onMouseLeave={() => onMemberHover(null)}
+								onClick={() => onMemberSelect(member.memberId)}
+							/>
+						);
+					})}
+				</ul>
+				<div className="mt-4 ml-auto">
+					<Button variant="text" className="ml-auto" onClick={onClearSelected}>
+						Clear Selected
+					</Button>
+				</div>
+			</div>
+
+			<div className="flex flex-col py-2">
+				<div className="flex items-center justify-between">
+					<Typography variant="h6">Pending Responders</Typography>
+					{isOwner && pendingMembers.length > 0 && (
+						<Button
+							variant="outlined"
+							size="small"
+							startIcon={<NotificationsOutlined />}
+							disabled={isNudging || cooldownRemaining !== null}
+							onClick={onNudge}
+						>
+							Nudge
+						</Button>
+					)}
+				</div>
+
+				{isOwner && cooldownRemaining !== null && (
+					<Typography variant="caption" sx={{ color: "error.main", mt: 0.5 }}>
+						Nudge available in {cooldownRemaining}
+					</Typography>
+				)}
+
+				{pendingMembers.length > 0 ? (
+					<div>
+						<Typography variant="caption" color="textSecondary">
+							Waiting on responses from your group ({pendingMembers.length})
+						</Typography>
+						<ul className="mt-3 flex flex-wrap gap-2">
+							{pendingMembers.map((member) => (
+								<Chip
+									key={member.memberId}
+									icon={
+										<Avatar
+											alt={member.displayName}
+											src={member.profilePicture ?? undefined}
+											slotProps={{ img: { referrerPolicy: "no-referrer" } }}
+											sx={{ height: 24, width: 24 }}
+										/>
+									}
+									label={member.displayName}
+									variant="outlined"
+								/>
+							))}
+						</ul>
+					</div>
+				) : (
+					<Typography variant="caption" color="textSecondary" className="mt-2">
+						Everyone has submitted availability.
+					</Typography>
+				)}
+			</div>
+		</>
+	);
+}
+
 export function GroupResponses({
 	availabilityDates,
 	ifNeededDates,
@@ -103,6 +298,13 @@ export function GroupResponses({
 	meetingId,
 	isOwner,
 }: GroupResponsesProps) {
+	const isLgQuery = useMediaQuery(LG_UP_MEDIA, { noSsr: true });
+	const [layoutReady, setLayoutReady] = useState(false);
+	useEffect(() => {
+		setLayoutReady(true);
+	}, []);
+	const isLg = layoutReady ? isLgQuery : true;
+
 	const { showSuccess, showError } = useSnackbar();
 	const [isNudging, setIsNudging] = useState(false);
 	const [cooldownUntil, setCooldownUntil] = useState<Date | null>(null);
@@ -255,169 +457,52 @@ export function GroupResponses({
 		? formatRangeLabel(activeRange, newAvailDates)
 		: "Select a cell to view";
 
+	const handleCloseMobile = useCallback(() => {
+		setIsMobileDrawerOpen(false);
+	}, [setIsMobileDrawerOpen]);
+
+	const panelProps: Omit<GroupResponsesPanelProps, "variant"> = {
+		blockInfoString,
+		showBestTimes,
+		onShowBestTimesChange: setShowBestTimes,
+		respondedMembers,
+		memberStatus,
+		selectedMembers,
+		onMemberHover: handleMemberHover,
+		onMemberSelect: handleMemberSelect,
+		onClearSelected: handleClearSelected,
+		availableCount,
+		isOwner,
+		pendingMembers,
+		isNudging,
+		cooldownRemaining,
+		onNudge: () => {
+			void handleNudge();
+		},
+		onRequestClose: handleCloseMobile,
+	};
+
+	if (!isLg) {
+		return (
+			<MuiBottomSheet
+				open={isMobileDrawerOpen}
+				onClose={handleCloseMobile}
+				paperSx={{ px: 2, py: 1 }}
+			>
+				<div data-availability-sidebar="">
+					<GroupResponsesPanel {...panelProps} variant="mobile" />
+				</div>
+			</MuiBottomSheet>
+		);
+	}
+
 	return (
 		<div
 			data-availability-sidebar=""
 			className="flex min-h-0 min-w-0 flex-1 flex-col lg:shrink-0"
 		>
-			<div
-				className={cn(
-					"fixed bottom-0 h-96 max-h-[85dvh] w-full min-w-0 translate-y-full overflow-auto rounded-t-xl bg-opacity-90 px-4 transition-transform duration-500 ease-in-out sm:right-0 sm:left-auto sm:w-96 lg:relative lg:top-0 lg:h-full lg:max-h-none lg:min-h-0 lg:w-full lg:flex-1 lg:shrink-0 lg:translate-y-0 lg:self-stretch lg:overflow-y-auto lg:overscroll-y-contain lg:rounded-l-xl lg:bg-opacity-50",
-					isMobileDrawerOpen && "translate-y-0",
-				)}
-			>
-				<div className="hidden pb-3 lg:block">
-					<Typography variant="h6">Attendees</Typography>
-					<Typography variant="caption" color="textSecondary">
-						{blockInfoString}
-					</Typography>
-				</div>
-
-				<div className="flex items-center justify-between py-4 lg:hidden">
-					<div>
-						<h3 className="font-medium">Responders</h3>
-						<Typography variant="caption" color="textSecondary">
-							{blockInfoString}
-						</Typography>
-					</div>
-					<button
-						type="button"
-						className="rounded-lg border-[1px] border-slate-400 p-0.5 lg:hidden"
-						onClick={() => setIsMobileDrawerOpen(false)}
-					>
-						<XIcon className="text-lg text-slate-400" />
-					</button>
-				</div>
-
-				<div className="mt-3 flex flex-col">
-					<div>
-						<Typography variant="h6">Map Display</Typography>
-						<Typography variant="caption" color="textSecondary">
-							Filter how responder availability shows together on the map
-						</Typography>
-					</div>
-
-					<div className="mt-2 flex items-center gap-2">
-						<Switch
-							id="availability-best-times"
-							checked={showBestTimes}
-							onChange={(e) => setShowBestTimes(e.target.checked)}
-							size="medium"
-							inputProps={{ "aria-label": "Best Times" }}
-						/>
-						<label
-							htmlFor="availability-best-times"
-							className="cursor-pointer text-md"
-						>
-							Best Times
-						</label>
-					</div>
-				</div>
-
-				<div className="flex flex-col py-2">
-					<div>
-						<h2 className="font-medium text-xl">Responders</h2>
-						<Typography variant="caption" color="textSecondary">
-							Available ({availableCount})
-						</Typography>
-					</div>
-
-					<ul className="mt-3 flex flex-wrap gap-2">
-						{respondedMembers.map((member) => {
-							const status = memberStatus.get(member.memberId) ?? "available";
-							return (
-								<Chip
-									key={member.memberId}
-									clickable
-									icon={
-										<Avatar
-											alt={member.displayName}
-											src={member.profilePicture ?? undefined}
-											slotProps={{ img: { referrerPolicy: "no-referrer" } }}
-											sx={{ width: 24, height: 24, fontSize: 12 }}
-										/>
-									}
-									label={member.displayName}
-									color={
-										selectedMembers.includes(member.memberId)
-											? "primary"
-											: "default"
-									}
-									variant="outlined"
-									className={cn("max-w-full", RESPONDER_CHIP_CLASS[status])}
-									onMouseEnter={() => handleMemberHover(member.memberId)}
-									onMouseLeave={() => handleMemberHover(null)}
-									onClick={() => handleMemberSelect(member.memberId)}
-								/>
-							);
-						})}
-					</ul>
-					<div className="mt-4 ml-auto">
-						<Button
-							variant="text"
-							className="ml-auto"
-							onClick={handleClearSelected}
-						>
-							Clear Selected
-						</Button>
-					</div>
-				</div>
-
-				<div className="flex flex-col py-2">
-					<div className="flex items-center justify-between">
-						<Typography variant="h6">Pending Responders</Typography>
-						{isOwner && pendingMembers.length > 0 && (
-							<Button
-								variant="outlined"
-								size="small"
-								startIcon={<NotificationsOutlined />}
-								disabled={isNudging || cooldownRemaining !== null}
-								onClick={handleNudge}
-							>
-								Nudge
-							</Button>
-						)}
-					</div>
-
-					{isOwner && cooldownRemaining !== null && (
-						<Typography variant="caption" sx={{ color: "error.main", mt: 0.5 }}>
-							Nudge available in {cooldownRemaining}
-						</Typography>
-					)}
-
-					{pendingMembers.length > 0 ? (
-						<div>
-							<Typography variant="caption" color="textSecondary">
-								Waiting on responses from your group ({pendingMembers.length})
-							</Typography>
-							<ul className="mt-3 flex flex-wrap gap-2">
-								{pendingMembers.map((member) => (
-									<Chip
-										key={member.memberId}
-										icon={
-											<Avatar
-												alt={member.displayName}
-												src={member.profilePicture ?? undefined}
-												slotProps={{ img: { referrerPolicy: "no-referrer" } }}
-												sx={{ height: 24, width: 24 }}
-											/>
-										}
-										label={member.displayName}
-										variant="outlined"
-									/>
-								))}
-							</ul>
-						</div>
-					) : (
-						<Typography
-							variant="caption"
-							color="textSecondary"
-							className="mt-2"
-						>
-							Everyone has submitted availability.
-						</Typography>
-					)}
-				</div>
+			<div className="relative flex min-h-0 min-w-0 flex-1 flex-col self-stretch overflow-y-auto overscroll-y-contain px-4 lg:h-full lg:max-h-none">
+				<GroupResponsesPanel {...panelProps} variant="desktop" />
 			</div>
 		</div>
 	);

--- a/src/components/availability/mobile-group-responses.tsx
+++ b/src/components/availability/mobile-group-responses.tsx
@@ -39,13 +39,11 @@ export function MobileGroupResponses({
 				<div className="flex w-full min-w-0">
 					<Button color="inherit" sx={actionButtonSx} onClick={onOpenAttendees}>
 						<Stack spacing={0.5} alignItems="center">
-							<Stack spacing={0.5} alignItems="center">
-								<PeopleAltOutlined fontSize="small" />
-								<Typography variant="caption">
-									{respondedMembersCount} /{" "}
-									{pendingMembersCount + respondedMembersCount} Responders
-								</Typography>
-							</Stack>
+							<PeopleAltOutlined fontSize="small" />
+							<Typography variant="caption">
+								{respondedMembersCount} /{" "}
+								{pendingMembersCount + respondedMembersCount} Responders
+							</Typography>
 						</Stack>
 					</Button>
 

--- a/src/components/availability/mobile-group-responses.tsx
+++ b/src/components/availability/mobile-group-responses.tsx
@@ -39,11 +39,13 @@ export function MobileGroupResponses({
 				<div className="flex w-full min-w-0">
 					<Button color="inherit" sx={actionButtonSx} onClick={onOpenAttendees}>
 						<Stack spacing={0.5} alignItems="center">
-							<PeopleAltOutlined fontSize="small" />
-							<Typography variant="caption">
-								{respondedMembersCount} /{" "}
-								{pendingMembersCount + respondedMembersCount} Responders
-							</Typography>
+							<Stack spacing={0.5} alignItems="center">
+								<PeopleAltOutlined fontSize="small" />
+								<Typography variant="caption">
+									{respondedMembersCount} /{" "}
+									{pendingMembersCount + respondedMembersCount} Responders
+								</Typography>
+							</Stack>
 						</Stack>
 					</Button>
 

--- a/src/components/availability/table/availability-nav-button.tsx
+++ b/src/components/availability/table/availability-nav-button.tsx
@@ -16,6 +16,7 @@ export const AvailabilityNavButton = memo(
 				onClick={handleClick}
 				disabled={disabled}
 				size="small"
+				aria-label={direction === "left" ? "Previous dates" : "Next dates"}
 				sx={{ opacity: disabled ? 0 : 1 }}
 			>
 				{direction === "left" ? (

--- a/src/components/availability/table/availability-table-header.tsx
+++ b/src/components/availability/table/availability-table-header.tsx
@@ -1,5 +1,6 @@
 import { Typography } from "@mui/material";
 import React from "react";
+import { AvailabilityNavButton } from "@/components/availability/table/availability-nav-button";
 import type { SelectMeeting } from "@/db/schema";
 import {
 	cloneBlocks,
@@ -8,6 +9,13 @@ import {
 } from "@/lib/availability/utils";
 import type { ZotDate } from "@/lib/zotdate";
 
+export interface AvailabilityDatePageNav {
+	onPrev: () => void;
+	onNext: () => void;
+	isFirstPage: boolean;
+	isLastPage: boolean;
+}
+
 interface AvailabilityTableHeaderProps {
 	currentPageAvailability: {
 		availabilities: (ZotDate | null)[];
@@ -15,12 +23,14 @@ interface AvailabilityTableHeaderProps {
 	};
 	meetingType: SelectMeeting["meetingType"];
 	doesntNeedDay: boolean;
+	datePageNav?: AvailabilityDatePageNav;
 }
 
 export function AvailabilityTableHeader({
 	currentPageAvailability,
 	meetingType,
 	doesntNeedDay,
+	datePageNav,
 }: AvailabilityTableHeaderProps) {
 	const newBlocks = cloneBlocks(
 		currentPageAvailability.availabilities,
@@ -28,6 +38,8 @@ export function AvailabilityTableHeader({
 	);
 
 	const spacers = spacerBeforeDate(newBlocks);
+	const lastIndex = newBlocks.length - 1;
+
 	return (
 		<thead>
 			<tr>
@@ -35,32 +47,70 @@ export function AvailabilityTableHeader({
 					<span className="sr-only">Time</span>
 				</th>
 
-				{newBlocks.map((dateHeader, index) => (
-					<React.Fragment key={index}>
-						{spacers[index] && (
-							<th className="w-3 md:w-4" tabIndex={-1} aria-hidden="true" />
-						)}
-						<th className="font-normal text-sm">
-							<div className="flex flex-col">
-								<Typography
-									variant="caption"
-									color="textSecondary"
-									className="uppercase"
-								>
-									{dateHeader?.day.toLocaleDateString("en-US", {
-										weekday: "short",
-									})}
-								</Typography>
+				{newBlocks.map((dateHeader, index) => {
+					const dateContent = (
+						<div className="flex w-full min-w-0 flex-col items-center text-center">
+							<Typography
+								variant="caption"
+								color="textSecondary"
+								className="uppercase"
+							>
+								{dateHeader?.day.toLocaleDateString("en-US", {
+									weekday: "short",
+								})}
+							</Typography>
 
-								{meetingType === "dates" && (
-									<Typography>
-										{dateHeader?.day && formatDateToUSNumeric(dateHeader.day)}
-									</Typography>
-								)}
-							</div>
-						</th>
-					</React.Fragment>
-				))}
+							{meetingType === "dates" && (
+								<Typography>
+									{dateHeader?.day && formatDateToUSNumeric(dateHeader.day)}
+								</Typography>
+							)}
+						</div>
+					);
+
+					let cellInner: React.ReactNode = dateContent;
+					if (datePageNav) {
+						const n = newBlocks.length;
+						const showLeft = n === 1 || index === 0;
+						const showRight = n === 1 || index === lastIndex;
+						if (showLeft || showRight) {
+							cellInner = (
+								<div className="relative flex min-h-11 w-full items-center justify-center py-0.5">
+									{showLeft && (
+										<span className="absolute top-1/2 left-0 z-[1] -translate-y-1/2">
+											<AvailabilityNavButton
+												direction="left"
+												handleClick={datePageNav.onPrev}
+												disabled={datePageNav.isFirstPage}
+											/>
+										</span>
+									)}
+									<div className="flex w-full justify-center px-9">
+										{dateContent}
+									</div>
+									{showRight && (
+										<span className="absolute top-1/2 right-0 z-[1] -translate-y-1/2">
+											<AvailabilityNavButton
+												direction="right"
+												handleClick={datePageNav.onNext}
+												disabled={datePageNav.isLastPage}
+											/>
+										</span>
+									)}
+								</div>
+							);
+						}
+					}
+
+					return (
+						<React.Fragment key={index}>
+							{spacers[index] && (
+								<th className="w-3 md:w-4" tabIndex={-1} aria-hidden="true" />
+							)}
+							<th className="font-normal text-sm">{cellInner}</th>
+						</React.Fragment>
+					);
+				})}
 			</tr>
 		</thead>
 	);

--- a/src/components/groups/group-settings-form.tsx
+++ b/src/components/groups/group-settings-form.tsx
@@ -4,7 +4,6 @@ import { AddAPhoto, Close, Delete } from "@mui/icons-material";
 import {
 	Avatar,
 	Button,
-	Drawer,
 	IconButton,
 	TextField,
 	Typography,
@@ -17,6 +16,7 @@ import {
 	compressImage,
 	MAX_GROUP_ICON_FILE_SIZE,
 } from "@/components/groups/create-group-dialog";
+import { MuiBottomSheet } from "@/components/ui/mui/mui-bottom-sheet";
 import { useSnackbar } from "@/components/ui/snackbar-provider";
 import type { SelectGroup } from "@/db/schema";
 import { deleteGroup } from "@/server/actions/group/delete/action";
@@ -228,21 +228,16 @@ export function GroupSettingsForm({ group, onCancel }: GroupSettingsFormProps) {
 				)}
 			</div>
 			{isMobile && (
-				<Drawer
-					anchor="bottom"
+				<MuiBottomSheet
 					open={showDeleteConfirm}
 					onClose={() => {
 						setShowDeleteConfirm(false);
 						setDeleteConfirmName("");
 					}}
-					slotProps={{
-						paper: {
-							sx: {
-								borderTopLeftRadius: 16,
-								borderTopRightRadius: 16,
-								p: 3,
-							},
-						},
+					paperSx={{
+						borderTopLeftRadius: 16,
+						borderTopRightRadius: 16,
+						p: 3,
 					}}
 				>
 					<div className="flex flex-col gap-4">
@@ -284,7 +279,7 @@ export function GroupSettingsForm({ group, onCancel }: GroupSettingsFormProps) {
 							{isDeletingGroup ? "Deleting..." : "Delete Group"}
 						</Button>
 					</div>
-				</Drawer>
+				</MuiBottomSheet>
 			)}
 		</div>
 	);

--- a/src/components/ui/mui/mui-bottom-sheet.tsx
+++ b/src/components/ui/mui/mui-bottom-sheet.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { DrawerProps } from "@mui/material/Drawer";
+import Drawer from "@mui/material/Drawer";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { ReactNode } from "react";
+
+const basePaperSx: SxProps<Theme> = {
+	borderTopLeftRadius: 12,
+	borderTopRightRadius: 12,
+	maxHeight: "85dvh",
+	overflow: "auto",
+};
+
+export type MuiBottomSheetProps = Omit<
+	DrawerProps,
+	"anchor" | "children" | "open" | "onClose"
+> & {
+	open: boolean;
+	onClose: NonNullable<DrawerProps["onClose"]>;
+	children: ReactNode;
+	/** Applied after base sheet styles; later entries win for the same keys. */
+	paperSx?: SxProps<Theme>;
+};
+
+function stripSxFromPaperSlot(paper: unknown): Record<string, unknown> {
+	if (!paper || typeof paper !== "object" || Array.isArray(paper)) {
+		return {};
+	}
+	return Object.fromEntries(
+		Object.entries(paper as Record<string, unknown>).filter(
+			([k]) => k !== "sx",
+		),
+	);
+}
+
+function paperSlotSx(paper: unknown): SxProps<Theme> | undefined {
+	if (!paper || typeof paper !== "object" || Array.isArray(paper)) {
+		return undefined;
+	}
+	return "sx" in paper ? (paper as { sx?: SxProps<Theme> }).sx : undefined;
+}
+
+/**
+ * Opinionated MUI bottom {@link Drawer} for modal sheets (rounded top,
+ * max height, scroll). Pass `paperSx` to override padding or corner radius.
+ */
+export function MuiBottomSheet({
+	open,
+	onClose,
+	children,
+	paperSx,
+	slotProps,
+	...rest
+}: MuiBottomSheetProps) {
+	const incomingPaper = slotProps?.paper;
+	const paperRest = stripSxFromPaperSlot(incomingPaper);
+	const incomingSx = paperSlotSx(incomingPaper);
+
+	return (
+		<Drawer
+			anchor="bottom"
+			open={open}
+			onClose={onClose}
+			slotProps={{
+				...slotProps,
+				paper: {
+					...paperRest,
+					sx: [basePaperSx, incomingSx, paperSx].filter(
+						Boolean,
+					) as SxProps<Theme>,
+				},
+			}}
+			{...rest}
+		>
+			{children}
+		</Drawer>
+	);
+}

--- a/src/components/ui/mui/mui-bottom-sheet.tsx
+++ b/src/components/ui/mui/mui-bottom-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DrawerProps } from "@mui/material/Drawer";
+import type { DrawerOwnerState, DrawerProps } from "@mui/material/Drawer";
 import Drawer from "@mui/material/Drawer";
 import type { SxProps, Theme } from "@mui/material/styles";
 import type { ReactNode } from "react";
@@ -41,10 +41,21 @@ function paperSlotSx(paper: unknown): SxProps<Theme> | undefined {
 	return "sx" in paper ? (paper as { sx?: SxProps<Theme> }).sx : undefined;
 }
 
-/**
- * Opinionated MUI bottom {@link Drawer} for modal sheets (rounded top,
- * max height, scroll). Pass `paperSx` to override padding or corner radius.
- */
+function mergePaperSlotProps(
+	resolved: unknown,
+	extraPaperSx: SxProps<Theme> | undefined,
+): Record<string, unknown> & { sx: SxProps<Theme> } {
+	const paperRest = stripSxFromPaperSlot(resolved);
+	const resolvedSx = paperSlotSx(resolved);
+	const sxLayers: SxProps<Theme>[] = [basePaperSx];
+	if (resolvedSx != null) sxLayers.push(resolvedSx);
+	if (extraPaperSx != null) sxLayers.push(extraPaperSx);
+	return {
+		...paperRest,
+		sx: (sxLayers.length === 1 ? sxLayers[0] : sxLayers) as SxProps<Theme>,
+	};
+}
+
 export function MuiBottomSheet({
 	open,
 	onClose,
@@ -54,8 +65,12 @@ export function MuiBottomSheet({
 	...rest
 }: MuiBottomSheetProps) {
 	const incomingPaper = slotProps?.paper;
-	const paperRest = stripSxFromPaperSlot(incomingPaper);
-	const incomingSx = paperSlotSx(incomingPaper);
+
+	const paperSlot =
+		typeof incomingPaper === "function"
+			? (ownerState: DrawerOwnerState) =>
+					mergePaperSlotProps(incomingPaper(ownerState), paperSx)
+			: mergePaperSlotProps(incomingPaper, paperSx);
 
 	return (
 		<Drawer
@@ -64,12 +79,7 @@ export function MuiBottomSheet({
 			onClose={onClose}
 			slotProps={{
 				...slotProps,
-				paper: {
-					...paperRest,
-					sx: [basePaperSx, incomingSx, paperSx].filter(
-						Boolean,
-					) as SxProps<Theme>,
-				},
+				paper: paperSlot,
 			}}
 			{...rest}
 		>


### PR DESCRIPTION
## Description

- allow users to trigger the responder list drawer on mobile by clicking a cell, selecting multiple cells, or clicking the island 
- repositions page chevrons and refactors into availability-table-header.tsx


<img width="410" height="858" alt="image" src="https://github.com/user-attachments/assets/e87772ff-306f-4bc2-83ae-2e45b9c66f04" />

<img width="372" height="130" alt="image" src="https://github.com/user-attachments/assets/711f0f56-e064-4793-aac7-6bff58394cbf" />

https://github.com/user-attachments/assets/2592ebac-90a7-45c4-ad0c-a0a18361bfe0



- Closes #


