### PR TITLE
fix: 🐛 remove invited members from responder count

### DIFF
--- a/src/server/data/meeting/queries.ts
+++ b/src/server/data/meeting/queries.ts
@@ -150,7 +150,16 @@ export async function getResponderCountsByMeetingIds(
 			respondedCount: countDistinct(availabilities.memberId),
 		})
 		.from(availabilities)
-		.where(inArray(availabilities.meetingId, meetingIds))
+		.where(
+			and(
+				inArray(availabilities.meetingId, meetingIds),
+				or(
+					sql`COALESCE(jsonb_array_length(${availabilities.meetingAvailabilities}), 0) > 0`,
+					sql`COALESCE(jsonb_array_length(${availabilities.ifNeededAvailabilities}), 0) > 0`,
+				),
+			),
+		)
+
 		.groupBy(availabilities.meetingId);
 
 	return Object.fromEntries(


### PR DESCRIPTION
## Description
- Added check for "invited" and "if-needed" while calculating meeting responders


### Before

https://github.com/user-attachments/assets/42268654-7e72-4bac-b1f4-214f76441ca5


### After

https://github.com/user-attachments/assets/ddde1ee6-0518-4a74-8e40-9907d490ce91


- Closes #
https://github.com/icssc/ZotMeet/issues/494
<!-- ## Future Follow-Up -->
