### PR TITLE
UI Inconsistencies

### DIFF
--- a/src/app/studyrooms/page.tsx
+++ b/src/app/studyrooms/page.tsx
@@ -104,7 +104,7 @@ export default function Page() {
 				</Typography>
 			)}
 			<div className="block sm:hidden">
-				<Typography variant="h3" className="p-4">
+				<Typography variant="h4" className="p-6">
 					Rooms
 				</Typography>
 			</div>

--- a/src/components/creation/creation.tsx
+++ b/src/components/creation/creation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createMeeting } from "@actions/meeting/create/action";
-import { Button } from "@mui/material";
+import { Button, Paper } from "@mui/material";
 import {
 	parseAsArrayOf,
 	parseAsString,
@@ -183,7 +183,10 @@ export function Creation({ user }: { user: UserProfile | null }) {
 	}, [selectedDays.length, startTime, endTime, hasMeetingName]);
 
 	return (
-		<div className="mx-auto my-6 flex w-full max-w-6xl flex-col gap-y-6 px-0 md:my-8 md:w-[calc(100%-2rem)] md:rounded-xl md:border md:border-gray-300 md:px-4">
+		<Paper
+			variant="outlined"
+			className="mx-auto my-6 flex w-full max-w-6xl flex-col gap-y-6 px-0 md:my-8 md:w-[calc(100%-2rem)] md:px-4"
+		>
 			<div className="px-2 pt-2 md:pt-2 md:pl-[40px]"></div>
 			<div className="w-full px-2 py-6 md:px-14">
 				<h2 className="hidden font-medium text-2xl sm:block md:text-3xl">
@@ -241,6 +244,6 @@ export function Creation({ user }: { user: UserProfile | null }) {
 			</div>
 
 			<div className="px-2 pt-2 md:pt-2 md:pl-[40px]"></div>
-		</div>
+		</Paper>
 	);
 }

--- a/src/components/creation/fields/meeting-name-field.tsx
+++ b/src/components/creation/fields/meeting-name-field.tsx
@@ -31,6 +31,11 @@ export function MeetingNameField({
 				onChange={handleChange}
 				onBlur={() => onBlur(value)}
 				autoFocus
+				InputProps={{
+					sx: {
+						fontSize: { xs: "1.125rem", sm: "1.3rem" },
+					},
+				}}
 			/>
 		</div>
 	);

--- a/src/components/creation/fields/meeting-time-field.tsx
+++ b/src/components/creation/fields/meeting-time-field.tsx
@@ -1,34 +1,28 @@
-import { TextField } from "@mui/material";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import { type Dispatch, type SetStateAction, useMemo } from "react";
 import type { HourMinuteString } from "@/lib/types/chrono";
 
-const convertTo24Hour = (hour: number, period: string) => {
-	if (period === "PM" && hour !== 12) {
-		hour += 12;
-	} else if (period === "AM" && hour === 12) {
-		hour = 0;
-	}
-	return hour.toString().padStart(2, "0");
-};
+function hourMinuteStringToDate(time: HourMinuteString): Date {
+	const [h = 0, m = 0, s = 0] = time
+		.split(":")
+		.map((part) => Number.parseInt(part, 10));
+	const d = new Date();
+	d.setHours(
+		Number.isFinite(h) ? h : 0,
+		Number.isFinite(m) ? m : 0,
+		Number.isFinite(s) ? s : 0,
+		0,
+	);
+	return d;
+}
 
-const parseHourMinuteString = (
-	time: HourMinuteString,
-): {
-	hour: number;
-	period: "AM" | "PM";
-} => {
-	const hour = parseInt(time.split(":")[0], 10);
-	let displayHour = hour;
-	const period = hour >= 12 ? "PM" : "AM";
-
-	if (hour > 12) {
-		displayHour = hour - 12;
-	} else if (hour === 0) {
-		displayHour = 12;
-	}
-
-	return { hour: displayHour, period };
-};
+function dateToHourMinuteString(date: Date): HourMinuteString {
+	const hh = date.getHours().toString().padStart(2, "0");
+	const mm = date.getMinutes().toString().padStart(2, "0");
+	return `${hh}:${mm}:00` as HourMinuteString;
+}
 
 interface MeetingTimeFieldProps {
 	startTime: HourMinuteString;
@@ -43,87 +37,44 @@ export const MeetingTimeField = ({
 	setStartTime,
 	setEndTime,
 }: MeetingTimeFieldProps) => {
-	const { hour: initialStartHour, period: initialStartPeriod } =
-		parseHourMinuteString(startTime);
-	const { hour: initialEndHour, period: initialEndPeriod } =
-		parseHourMinuteString(endTime);
-
-	const [startHour, setStartHour] = useState(initialStartHour);
-	const [startPeriod, setStartPeriod] = useState<"AM" | "PM">(
-		initialStartPeriod,
+	const startDate = useMemo(
+		() => hourMinuteStringToDate(startTime),
+		[startTime],
 	);
-	const [endHour, setEndHour] = useState(initialEndHour);
-	const [endPeriod, setEndPeriod] = useState<"AM" | "PM">(initialEndPeriod);
+	const endDate = useMemo(() => hourMinuteStringToDate(endTime), [endTime]);
 
-	const handleStartHourChange = (value: string) => {
-		const hour = parseInt(value, 10);
-		setStartHour(hour);
-		setStartTime(
-			`${convertTo24Hour(hour, startPeriod)}:00:00` as HourMinuteString,
-		);
-	};
-
-	const handleStartPeriodChange = (value: string) => {
-		setStartPeriod(value as "AM" | "PM");
-		setStartTime(
-			`${convertTo24Hour(startHour, value)}:00:00` as HourMinuteString,
-		);
-	};
-
-	const handleEndHourChange = (value: string) => {
-		const hour = parseInt(value, 10);
-		setEndHour(hour);
-		setEndTime(`${convertTo24Hour(hour, endPeriod)}:00:00` as HourMinuteString);
-	};
-
-	const handleEndPeriodChange = (value: string) => {
-		setEndPeriod(value as "AM" | "PM");
-		setEndTime(`${convertTo24Hour(endHour, value)}:00:00` as HourMinuteString);
+	const slotProps = {
+		textField: {
+			fullWidth: true,
+			size: "medium" as const,
+			sx: {
+				"& .MuiIconButton-edgeEnd": {
+					marginRight: 0,
+				},
+			},
+		},
 	};
 
 	return (
-		<div>
-			{/* <div className="flex w-full flex-col items-center space-y-4 pt-2 text-gray-500 text-sm"> */}
+		<LocalizationProvider dateAdapter={AdapterDateFns}>
 			<div className="flex w-full flex-col items-center gap-4 md:flex-row">
-				<TextField
-					fullWidth
+				<TimePicker
 					label="START TIME"
-					variant="outlined"
-					type="time"
-					size="medium"
-					placeholder="9:00 AM"
-					value={startTime}
-					onChange={(e) =>
-						setStartTime(`${e.target.value}:00` as HourMinuteString)
-					}
-					inputProps={{ style: { fontSize: "1rem" } }}
-					sx={(theme) => ({
-						"& input::-webkit-calendar-picker-indicator": {
-							filter: theme.palette.mode === "dark" ? "invert(1)" : "none",
-						},
-					})}
+					value={startDate}
+					onChange={(value) => {
+						if (value) setStartTime(dateToHourMinuteString(value));
+					}}
+					slotProps={slotProps}
 				/>
-
-				<TextField
-					fullWidth
+				<TimePicker
 					label="END TIME"
-					variant="outlined"
-					type="time"
-					size="medium"
-					placeholder="5:00 PM"
-					value={endTime}
-					onChange={(e) =>
-						setEndTime(`${e.target.value}:00` as HourMinuteString)
-					}
-					inputProps={{ style: { fontSize: "1rem" } }}
-					sx={(theme) => ({
-						"& input::-webkit-calendar-picker-indicator": {
-							filter: theme.palette.mode === "dark" ? "invert(1)" : "none",
-						},
-					})}
+					value={endDate}
+					onChange={(value) => {
+						if (value) setEndTime(dateToHourMinuteString(value));
+					}}
+					slotProps={slotProps}
 				/>
-				<div className="flex gap-2"></div>
 			</div>
-		</div>
+		</LocalizationProvider>
 	);
 };

--- a/src/components/groups/groups-page.tsx
+++ b/src/components/groups/groups-page.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { Add, ExpandMore, People } from "@mui/icons-material";
-import { Box, Button, Divider, Stack, Typography } from "@mui/material";
-import { Search } from "lucide-react";
+import SearchIcon from "@mui/icons-material/Search";
+import {
+	Box,
+	Button,
+	Divider,
+	Stack,
+	TextField,
+	Typography,
+} from "@mui/material";
 import { useMemo, useState } from "react";
 import { CreateGroupDialog } from "@/components/groups/create-group-dialog";
 import { GroupCard } from "@/components/groups/group-card";
@@ -106,27 +113,29 @@ export function GroupsPage({ groups }: GroupsPageProps) {
 				</Button>
 			</Box>
 
-			<Box sx={{ display: { xs: "block", sm: "flex" } }}>
-				<Box
-					sx={{
-						display: "flex",
-						alignItems: "center",
-						gap: 1.25,
-						borderRadius: 99,
-						bgcolor: "grey.100",
-						px: 2,
-						py: 1,
+			<Box sx={{ display: { xs: "block", sm: "flex" }, gap: { xs: 0, sm: 2 } }}>
+				<TextField
+					aria-label="Search meetings"
+					placeholder="Search"
+					size="small"
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					slotProps={{
+						input: {
+							startAdornment: (
+								<SearchIcon
+									sx={{ fontSize: 20, color: "text.disabled", mr: 0.5 }}
+								/>
+							),
+						},
 					}}
-				>
-					<Search size={20} color="var(--mui-palette-text-disabled, #9e9e9e)" />
-					<input
-						type="text"
-						placeholder="Search"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						className="bg-transparent text-base outline-none placeholder:text-gray-400"
-					/>
-				</Box>
+					sx={{
+						width: { xs: "100%", sm: "auto" },
+						flex: { xs: "none", sm: "1 1 0%" },
+						minWidth: { sm: 0 },
+						maxWidth: { sm: 460 },
+					}}
+				/>
 
 				<Box
 					sx={{
@@ -156,8 +165,6 @@ export function GroupsPage({ groups }: GroupsPageProps) {
 					</Button>
 				</Box>
 			</Box>
-
-			<Divider sx={{ mt: 2 }} />
 
 			<Box sx={{ mt: 2, display: "flex", gap: 0.5 }}>
 				<FilterChip

--- a/src/components/groups/groups-page.tsx
+++ b/src/components/groups/groups-page.tsx
@@ -6,6 +6,7 @@ import {
 	Box,
 	Button,
 	Divider,
+	IconButton,
 	Stack,
 	TextField,
 	Typography,
@@ -89,28 +90,22 @@ export function GroupsPage({ groups }: GroupsPageProps) {
 		<Box sx={{ width: "100%" }}>
 			<Box
 				sx={{
-					mt: 3,
 					mb: 4,
 					display: { xs: "flex", sm: "none" },
 					alignItems: "center",
 				}}
 			>
-				<Typography variant="h3">Groups</Typography>
-				<Button
-					type="button"
-					variant="contained"
-					onClick={() => setCreateDialogOpen(true)}
-					sx={{
-						fontSize: "2rem",
-						padding: 0,
-						ml: "auto",
-						minWidth: 0,
-						width: "3rem",
-						height: "3rem",
-					}}
-				>
-					+
-				</Button>
+				<Typography variant="h4">Groups</Typography>
+				<div className="ml-auto">
+					<Button
+						type="button"
+						variant="contained"
+						size="square"
+						onClick={() => setCreateDialogOpen(true)}
+					>
+						<Add />
+					</Button>
+				</div>
 			</Box>
 
 			<Box sx={{ display: { xs: "block", sm: "flex" }, gap: { xs: 0, sm: 2 } }}>

--- a/src/components/groups/groups-page.tsx
+++ b/src/components/groups/groups-page.tsx
@@ -110,7 +110,7 @@ export function GroupsPage({ groups }: GroupsPageProps) {
 
 			<Box sx={{ display: { xs: "block", sm: "flex" }, gap: { xs: 0, sm: 2 } }}>
 				<TextField
-					aria-label="Search meetings"
+					aria-label="Search groups"
 					placeholder="Search"
 					size="small"
 					value={search}

--- a/src/components/mobile/mobile-island.tsx
+++ b/src/components/mobile/mobile-island.tsx
@@ -7,7 +7,7 @@ type MobileIslandProps = {
 
 export function MobileIsland({ children }: MobileIslandProps) {
 	return (
-		<div className="pointer-events-none fixed inset-x-0 bottom-0 z-[1001] flex justify-center px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+		<div className="pointer-events-none fixed inset-x-0 bottom-0 z-[1001] flex justify-center px-2 pb-[max(4rem,env(safe-area-inset-bottom))]">
 			<Paper
 				elevation={3}
 				sx={{

--- a/src/components/nav/mui-app-shell.tsx
+++ b/src/components/nav/mui-app-shell.tsx
@@ -14,9 +14,7 @@ type MuiAppShellProps = {
 
 /** Routes that render a custom bottom bar (e.g. mobile island) instead of MUI bottom nav. */
 function routeHidesBottomNav(pathname: string) {
-	return (
-		pathname.startsWith("/availability") || pathname.startsWith("/studyrooms")
-	);
+	return pathname.startsWith("/availability");
 }
 
 export function MuiAppShell({

--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -125,7 +125,7 @@ export const RoomsHeatmap = ({
 				<Table
 					size="small"
 					sx={{
-						borderCollapse: "collapse",
+						borderCollapse: "separate",
 						borderSpacing: 0,
 						fontSize: "0.7rem",
 					}}
@@ -135,10 +135,11 @@ export const RoomsHeatmap = ({
 							<TableCell
 								sx={(theme) => ({
 									position: "sticky",
-									left: 0,
-									zIndex: 2,
+									left: -3,
+									zIndex: 3,
 									minWidth: 200,
 									backgroundColor: theme.palette.background.paper,
+									boxShadow: `1px 0 0 ${theme.palette.divider}`,
 								})}
 							>
 								Rooms
@@ -168,8 +169,8 @@ export const RoomsHeatmap = ({
 										className="whitespace-nowrap"
 										sx={(theme) => ({
 											position: "sticky",
-											left: 0,
-											zIndex: 1,
+											left: -3,
+											zIndex: 2,
 											minWidth: 200,
 											backgroundColor: theme.palette.background.paper,
 										})}

--- a/src/components/summary/meetings.tsx
+++ b/src/components/summary/meetings.tsx
@@ -255,18 +255,9 @@ export const Meetings = ({
 					>
 						<Notifications sx={{ color: "text.primary", fontSize: 24 }} />
 					</Box>
-					<IconButton
-						aria-label="Create a meeting"
-						component={Link}
-						href="/"
-						sx={{
-							bgcolor: "primary.main",
-							borderRadius: 1,
-							"&:hover": { bgcolor: "primary.dark" },
-						}}
-					>
-						<Add sx={{ color: "white" }} />
-					</IconButton>
+					<Button variant="contained" size="square" href="/">
+						<Add />
+					</Button>
 				</Box>
 			</Box>
 


### PR DESCRIPTION
## Description

## Recording/Screenshots

1. Meeting/Group Headers now consistent
<img width="876" height="184" alt="image" src="https://github.com/user-attachments/assets/04b1bd99-8b5a-448a-b6ea-d3a06f48f0dc" />
<img width="876" height="184" alt="image" src="https://github.com/user-attachments/assets/a1512e71-5bcd-49fc-8cd4-de349da2a812" />


2. navbar on /rooms
<img width="418" height="237" alt="image" src="https://github.com/user-attachments/assets/565b0e76-c800-45fd-87d1-6ea96f9387ac" />

3. MUI Paper on homepage
<img width="1169" height="976" alt="image" src="https://github.com/user-attachments/assets/8b732a22-c3c3-48bf-a416-f4b3c53556ad" />

4. default MUI timepicker
<img width="267" height="396" alt="image" src="https://github.com/user-attachments/assets/3ffce685-e340-4643-b54f-9035659bd4ee" />

5. color bleed thru
<img width="337" height="372" alt="image" src="https://github.com/user-attachments/assets/0ddeb91b-4d1f-4e44-b617-15808c7e9061" />


6. Mobile Meeting/Group Headers consistent
<img width="388" height="256" alt="image" src="https://github.com/user-attachments/assets/c72c653f-8858-4f73-9a03-fcf7a438f166" />
<img width="388" height="256" alt="image" src="https://github.com/user-attachments/assets/98320589-d9bf-472f-8e56-9b7e84d307d5" />



- Closes
https://github.com/icssc/ZotMeet/issues/511

<!-- ## Future Follow-Up -->
