### PR TITLE
fix: 🐛 room sort

### DIFF
--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -21,7 +21,7 @@ import {
 	groupSlotsIntoIntervals,
 	mergeDateAndTime,
 } from "@/lib/rooms/utils";
-import type { StudyRooms } from "@/lib/types/studyrooms";
+import { BUILDINGS, type StudyRooms } from "@/lib/types/studyrooms";
 import { cn } from "@/lib/utils";
 
 interface RoomsHeatmapProps {
@@ -31,12 +31,23 @@ interface RoomsHeatmapProps {
 	endTime: Date;
 }
 
-type SortKey =
-	| "default"
-	| "location"
-	| "capacity"
-	| "availability"
-	| "techEnhanced";
+type SortKey = "default" | "capacity" | "availability";
+
+const LOCATION_SORT_ORDER: readonly string[] = [
+	"Science Library",
+	...BUILDINGS.filter((b) => b !== "Science Library"),
+];
+
+function compareLocationSort(a: string, b: string): number {
+	const ia = LOCATION_SORT_ORDER.indexOf(a);
+	const ib = LOCATION_SORT_ORDER.indexOf(b);
+	const aKnown = ia >= 0;
+	const bKnown = ib >= 0;
+	if (aKnown && bKnown) return ia - ib;
+	if (aKnown && !bKnown) return -1;
+	if (!aKnown && bKnown) return 1;
+	return a.localeCompare(b);
+}
 
 export const RoomsHeatmap = ({
 	rooms,
@@ -70,14 +81,14 @@ export const RoomsHeatmap = ({
 	const sortedRooms = useMemo(() => {
 		const copy = rooms.filter((r) => r.name);
 		switch (sortBy) {
-			case "location":
-				return copy.sort((a, b) => a.location.localeCompare(b.location));
+			case "default":
+				return copy.sort((a, b) => compareLocationSort(a.location, b.location));
 			case "capacity":
 				return copy.sort((a, b) => {
 					if (!a.capacity && !b.capacity) return 0;
 					if (!a.capacity) return 1;
 					if (!b.capacity) return -1;
-					return a.capacity - b.capacity;
+					return b.capacity - a.capacity;
 				});
 			case "availability": {
 				const countAvailable = (room: (typeof rooms)[number]) =>
@@ -86,12 +97,10 @@ export const RoomsHeatmap = ({
 					).length;
 				return copy.sort((a, b) => countAvailable(b) - countAvailable(a));
 			}
-			case "techEnhanced":
-				return copy.sort(
-					(a, b) => Number(b.techEnhanced) - Number(a.techEnhanced),
-				);
-			default:
-				return copy;
+			default: {
+				const _exhaustive: never = sortBy;
+				return _exhaustive;
+			}
 		}
 	}, [rooms, sortBy, windowStart]);
 
@@ -111,10 +120,8 @@ export const RoomsHeatmap = ({
 						onChange={(e) => setSortBy(e.target.value as SortKey)}
 					>
 						<MenuItem value="default">Default</MenuItem>
-						<MenuItem value="location">Location</MenuItem>
 						<MenuItem value="capacity">Capacity</MenuItem>
 						<MenuItem value="availability">Availability</MenuItem>
-						<MenuItem value="techEnhanced">Tech Enhanced</MenuItem>
 					</Select>
 				</FormControl>
 			</Stack>


### PR DESCRIPTION
## Description
- Removed "Location" tab. (Was just an alphabetized version of "default" )
- Plaza Verde now defaulted to bottom
- Science library defaulted to top 
- Capacity now sorts from largest to smallest rooms

## Recording/Screenshots

### Before (was unsorted, had more science library rooms mingled in the middle)
<img width="1440" height="591" alt="image" src="https://github.com/user-attachments/assets/8744237f-e019-49ad-9e5e-147628283087" />
<img width="1440" height="591" alt="image" src="https://github.com/user-attachments/assets/2e446c1e-bd83-4d2e-a212-225eae293560" />


### After
<img width="1440" height="591" alt="image" src="https://github.com/user-attachments/assets/56869aa6-2a9b-453a-a976-2e62a8531b83" />

## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #

<!-- ## Future Follow-Up -->
