### PR TITLE
feat: ✨ availability heatmap jagged edges

### DIFF
--- a/src/components/availability/availability.tsx
+++ b/src/components/availability/availability.tsx
@@ -3,7 +3,7 @@
 import { Paper } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { AvailabilityActions } from "@/components/availability/availability-actions";
 import { GroupAvailability } from "@/components/availability/group-availability";
@@ -11,6 +11,7 @@ import { GroupResponses } from "@/components/availability/group-responses";
 import { AvailabilityHeader } from "@/components/availability/header/availability-header";
 import { PersonalAvailability } from "@/components/availability/personal-availability";
 import { RoomRecommendationSettings } from "@/components/availability/room-recommendations";
+import { AvailabilityGridJaggedEdges } from "@/components/availability/table/availability-grid-jagged-edges";
 import { AvailabilityTableHeader } from "@/components/availability/table/availability-table-header";
 import { TimeZoneDropdown } from "@/components/availability/table/availability-timezone";
 import { InviteMembersDialog } from "@/components/groups/add-member-dialog";
@@ -26,6 +27,7 @@ import {
 	clearPersonalGridSlots,
 	convertTimeFromUTC,
 	generateTimeBlocks,
+	getPageEdgeVariant,
 	getTimeFromHourMinuteString,
 	mergeImportedPersonalGridSlots,
 	sortMeetingIsoDatesAsc,
@@ -181,8 +183,16 @@ export function Availability({
 	const { calendars: googleCalendars, visibleEvents: visibleCalendarEvents } =
 		useCalendarOverlays(googleCalendarEvents);
 
-	const isLastPage =
-		currentPage === Math.floor((meetingData.dates.length - 1) / itemsPerPage);
+	const lastPage = Math.floor((availabilityDates.length - 1) / itemsPerPage);
+	const hasMultiplePages = lastPage > 0;
+	const isLastPage = currentPage === lastPage;
+	const pageEdgeVariant = getPageEdgeVariant(
+		hasMultiplePages,
+		isFirstPage,
+		isLastPage,
+	);
+
+	const availabilityGridRef = useRef<HTMLTableElement>(null);
 
 	const { handlers, gridHandlers, handleMouseLeave } = useGridInteraction({
 		availabilityView,
@@ -407,54 +417,66 @@ export function Availability({
 						<div className="shrink-0 lg:hidden">
 							<AvailabilityActions {...actionsProps} />
 						</div>
-						<table data-availability-grid="" className="w-full table-fixed">
-							<AvailabilityTableHeader
-								currentPageAvailability={currentPageAvailability}
-								meetingType={meetingData.meetingType}
-								doesntNeedDay={doesntNeedDay}
-								datePageNav={{
-									onPrev: prevPage,
-									onNext: () => nextPage(availabilityDates.length),
-									isFirstPage,
-									isLastPage,
-								}}
-							/>
-
-							<tbody
-								className="bg-stripes-primary"
-								onMouseLeave={handleMouseLeave}
+						<div className="relative overflow-visible">
+							<table
+								ref={availabilityGridRef}
+								data-availability-grid=""
+								className="w-full table-fixed"
 							>
-								{availabilityView === "group" ||
-								availabilityView === "schedule" ? (
-									<GroupAvailability
-										meetingTitle={meetingData.title}
-										availabilityTimeBlocks={availabilityTimeBlocks}
-										fromTime={fromTimeMinutes}
-										availabilityDates={availabilityDates}
-										ifNeededDates={ifNeededDates}
-										currentPageAvailability={currentPageAvailability}
-										members={members}
-										onMouseLeave={handleMouseLeave}
-										isScheduling={availabilityView === "schedule"}
-										timeZone={userTimezone}
-										handlers={gridHandlers}
-									/>
-								) : (
-									<PersonalAvailability
-										availabilityTimeBlocks={availabilityTimeBlocks}
-										fromTimeMinutes={fromTimeMinutes}
-										availabilityDates={availabilityDates}
-										currentPageAvailability={currentPageAvailability}
-										googleCalendarEvents={visibleCalendarEvents}
-										meetingDates={meetingData.dates}
-										userTimezone={userTimezone}
-										handlers={handlers}
-										paintMode={paintMode}
-										isDirty={isDirty}
-									/>
-								)}
-							</tbody>
-						</table>
+								<AvailabilityTableHeader
+									currentPageAvailability={currentPageAvailability}
+									meetingType={meetingData.meetingType}
+									doesntNeedDay={doesntNeedDay}
+									datePageNav={{
+										onPrev: prevPage,
+										onNext: () => nextPage(availabilityDates.length),
+										isFirstPage,
+										isLastPage,
+									}}
+								/>
+
+								<tbody
+									className="bg-stripes-primary"
+									onMouseLeave={handleMouseLeave}
+								>
+									{availabilityView === "group" ||
+									availabilityView === "schedule" ? (
+										<GroupAvailability
+											meetingTitle={meetingData.title}
+											availabilityTimeBlocks={availabilityTimeBlocks}
+											fromTime={fromTimeMinutes}
+											availabilityDates={availabilityDates}
+											ifNeededDates={ifNeededDates}
+											currentPageAvailability={currentPageAvailability}
+											members={members}
+											onMouseLeave={handleMouseLeave}
+											isScheduling={availabilityView === "schedule"}
+											timeZone={userTimezone}
+											handlers={gridHandlers}
+										/>
+									) : (
+										<PersonalAvailability
+											availabilityTimeBlocks={availabilityTimeBlocks}
+											fromTimeMinutes={fromTimeMinutes}
+											availabilityDates={availabilityDates}
+											currentPageAvailability={currentPageAvailability}
+											googleCalendarEvents={visibleCalendarEvents}
+											meetingDates={meetingData.dates}
+											userTimezone={userTimezone}
+											handlers={handlers}
+											paintMode={paintMode}
+											isDirty={isDirty}
+										/>
+									)}
+								</tbody>
+							</table>
+							{pageEdgeVariant !== "none" && (
+								<AvailabilityGridJaggedEdges
+									variant={pageEdgeVariant}
+									tableRef={availabilityGridRef}
+								/>
+							)}
+						</div>
 
 						<div className="ml-10 flex flex-row items-center justify-between gap-4 md:ml-16">
 							<TimeZoneDropdown

--- a/src/components/availability/table/availability-grid-jagged-edges.tsx
+++ b/src/components/availability/table/availability-grid-jagged-edges.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useTheme } from "@mui/material/styles";
+import { useEffect, useState } from "react";
+import type { PageEdgeVariant } from "@/lib/availability/utils";
+
+const EDGE_WIDTH = 10;
+const TOOTH_HEIGHT = 8;
+const TOOTH_DEPTH = 6;
+
+/** Filled strip with a sawtooth on the inner (right) edge. */
+function buildLeftEdgePath(height: number): string {
+	const teeth = Math.ceil(height / TOOTH_HEIGHT);
+	const parts = ["M 0 0", `L ${EDGE_WIDTH} 0`];
+	for (let i = 0; i < teeth; i++) {
+		const yPeak = Math.min(i * TOOTH_HEIGHT, height);
+		const yValley = Math.min((i + 0.5) * TOOTH_HEIGHT, height);
+		const yNextPeak = Math.min((i + 1) * TOOTH_HEIGHT, height);
+		if (yPeak < height) parts.push(`L ${EDGE_WIDTH} ${yPeak}`);
+		if (yValley < height)
+			parts.push(`L ${EDGE_WIDTH - TOOTH_DEPTH} ${yValley}`);
+		if (yNextPeak < height && i < teeth - 1) {
+			parts.push(`L ${EDGE_WIDTH} ${yNextPeak}`);
+		}
+	}
+	parts.push(`L 0 ${height}`, "Z");
+	return parts.join(" ");
+}
+
+/** Open path tracing only the inner zigzag edge of the left strip. */
+function buildLeftZigzagStroke(height: number): string {
+	const teeth = Math.ceil(height / TOOTH_HEIGHT);
+	const parts = [`M ${EDGE_WIDTH} 0`];
+	for (let i = 0; i < teeth; i++) {
+		const yValley = Math.min((i + 0.5) * TOOTH_HEIGHT, height);
+		const yNextPeak = Math.min((i + 1) * TOOTH_HEIGHT, height);
+		if (yValley < height)
+			parts.push(`L ${EDGE_WIDTH - TOOTH_DEPTH} ${yValley}`);
+		if (yNextPeak < height) parts.push(`L ${EDGE_WIDTH} ${yNextPeak}`);
+	}
+	return parts.join(" ");
+}
+
+/** Filled strip with a sawtooth on the inner (left) edge. */
+function buildRightEdgePath(height: number): string {
+	const teeth = Math.ceil(height / TOOTH_HEIGHT);
+	const parts = [`M ${EDGE_WIDTH} ${height}`, `L 0 ${height}`];
+	for (let i = teeth - 1; i >= 0; i--) {
+		const yNextPeak = Math.min((i + 1) * TOOTH_HEIGHT, height);
+		const yValley = Math.min((i + 0.5) * TOOTH_HEIGHT, height);
+		const yPeak = Math.min(i * TOOTH_HEIGHT, height);
+		if (yNextPeak > 0) parts.push(`L 0 ${yNextPeak}`);
+		if (yValley > 0) parts.push(`L ${TOOTH_DEPTH} ${yValley}`);
+		if (yPeak >= 0) parts.push(`L 0 ${yPeak}`);
+	}
+	parts.push(`L ${EDGE_WIDTH} 0`, "Z");
+	return parts.join(" ");
+}
+
+/** Open path tracing only the inner zigzag edge of the right strip. */
+function buildRightZigzagStroke(height: number): string {
+	const teeth = Math.ceil(height / TOOTH_HEIGHT);
+	const parts = ["M 0 0"];
+	for (let i = 0; i < teeth; i++) {
+		const yValley = Math.min((i + 0.5) * TOOTH_HEIGHT, height);
+		const yNextPeak = Math.min((i + 1) * TOOTH_HEIGHT, height);
+		if (yValley < height) parts.push(`L ${TOOTH_DEPTH} ${yValley}`);
+		if (yNextPeak < height) parts.push(`L 0 ${yNextPeak}`);
+	}
+	return parts.join(" ");
+}
+
+const GRAY_MEDIUM = "#9CA3AF";
+const GRAY_BASE = "#D1D5DB";
+
+interface AvailabilityGridJaggedEdgesProps {
+	variant: PageEdgeVariant;
+	tableRef: React.RefObject<HTMLTableElement | null>;
+}
+
+export function AvailabilityGridJaggedEdges({
+	variant,
+	tableRef,
+}: AvailabilityGridJaggedEdgesProps) {
+	const theme = useTheme();
+	const edgeFill = theme.palette.background.paper;
+	/** Matches grid vertical borders (gray-medium) / horizontal (gray-base) in light mode. */
+	const edgeStroke = theme.palette.mode === "dark" ? GRAY_BASE : GRAY_MEDIUM;
+
+	const [layout, setLayout] = useState({ top: 0, height: 0, left: 0 });
+
+	const showLeft = variant === "middle" || variant === "last";
+	const showRight = variant === "first" || variant === "middle";
+
+	useEffect(() => {
+		const table = tableRef.current;
+		if (!table) return;
+
+		const thead = table.querySelector("thead");
+		const tbody = table.querySelector("tbody");
+		if (!thead || !tbody) return;
+
+		const updateLayout = () => {
+			const timeCol = thead.querySelector("th");
+			setLayout({
+				top: tbody.offsetTop,
+				height: tbody.offsetHeight,
+				left: timeCol?.offsetWidth ?? 0,
+			});
+		};
+
+		updateLayout();
+
+		const observer = new ResizeObserver(updateLayout);
+		observer.observe(table);
+		observer.observe(thead);
+		observer.observe(tbody);
+
+		return () => observer.disconnect();
+	}, [tableRef]);
+
+	if (variant === "none" || layout.height <= 0) {
+		return null;
+	}
+
+	const edgeHeight = Math.round(layout.height);
+	const leftFillPath = buildLeftEdgePath(edgeHeight);
+	const leftStrokePath = buildLeftZigzagStroke(edgeHeight);
+	const rightFillPath = buildRightEdgePath(edgeHeight);
+	const rightStrokePath = buildRightZigzagStroke(edgeHeight);
+
+	const strokeProps = {
+		fill: "none",
+		stroke: edgeStroke,
+		strokeWidth: 1,
+		vectorEffect: "non-scaling-stroke" as const,
+	};
+
+	return (
+		<div
+			className="pointer-events-none absolute z-10"
+			style={{
+				top: layout.top,
+				left: layout.left,
+				right: 0,
+				height: layout.height,
+			}}
+			aria-hidden
+		>
+			{showLeft && (
+				<svg
+					className="absolute top-0 left-0 block overflow-visible"
+					width={EDGE_WIDTH}
+					height={edgeHeight}
+					aria-hidden
+					role="presentation"
+					focusable="false"
+				>
+					<path d={leftFillPath} fill={edgeFill} />
+					<path d={leftStrokePath} {...strokeProps} />
+				</svg>
+			)}
+			{showRight && (
+				<svg
+					className="absolute top-0 right-0 block overflow-visible"
+					width={EDGE_WIDTH}
+					height={edgeHeight}
+					aria-hidden
+					role="presentation"
+					focusable="false"
+				>
+					<path d={rightFillPath} fill={edgeFill} />
+					<path d={rightStrokePath} {...strokeProps} />
+				</svg>
+			)}
+		</div>
+	);
+}

--- a/src/components/availability/table/availability-grid-jagged-edges.tsx
+++ b/src/components/availability/table/availability-grid-jagged-edges.tsx
@@ -4,9 +4,9 @@ import { useTheme } from "@mui/material/styles";
 import { useEffect, useState } from "react";
 import type { PageEdgeVariant } from "@/lib/availability/utils";
 
-const EDGE_WIDTH = 10;
-const TOOTH_HEIGHT = 8;
-const TOOTH_DEPTH = 6;
+const EDGE_WIDTH = 12;
+const TOOTH_HEIGHT = 20;
+const TOOTH_DEPTH = 10;
 
 /** Filled strip with a sawtooth on the inner (right) edge. */
 function buildLeftEdgePath(height: number): string {

--- a/src/lib/availability/utils.ts
+++ b/src/lib/availability/utils.ts
@@ -128,6 +128,19 @@ export function generateCellKey(
 	return `${zotDateIndex}_${blockIndex}`;
 }
 
+export type PageEdgeVariant = "none" | "first" | "middle" | "last";
+
+export function getPageEdgeVariant(
+	hasMultiplePages: boolean,
+	isFirstPage: boolean,
+	isLastPage: boolean,
+): PageEdgeVariant {
+	if (!hasMultiplePages) return "none";
+	if (isFirstPage) return "first";
+	if (isLastPage) return "last";
+	return "middle";
+}
+
 export const spacerBeforeDate = (
 	currentPageAvailability: (ZotDate | null)[],
 ): boolean[] => {


### PR DESCRIPTION


## Key changes:
- /availability/utils.ts 
   - adds PageEdgeVariant, and getPageEdgeVariant() which decides which jagged edges should appear for current availability page

- /availability/availability.tsx
     - calculates the last page from availabilityDates.lenth and itemsPerPage
     - determines if user is on first/middle/last page and stores it in pageEdgeVariant

- /availability-grid-jagged-edjes.tsx
     - adds jagged edge svg overlay
     - measures table header/body with **ResizeObserver**


## Data flow: 
1. availability dates + current page 
2. getPageEdgeVariant()
3. AvailabilityGridJaggedEdges





## Recording/Screenshots

<img width="1114" height="666" alt="image" src="https://github.com/user-attachments/assets/0ab8edff-f93c-4451-bd66-5b27c5fcc596" />

<img width="1114" height="666" alt="image" src="https://github.com/user-attachments/assets/4502b3b4-f812-41fe-ac3c-04b6747ad645" />

<img width="1114" height="666" alt="image" src="https://github.com/user-attachments/assets/9324bbda-071f-4864-b86d-195f29083514" />

<img width="406" height="855" alt="image" src="https://github.com/user-attachments/assets/e4236f79-8c63-4c31-b291-07ff11749a94" />



- Closes 
https://github.com/icssc/ZotMeet/issues/496

