### PR TITLE
fix: 🐛 reduce search debounce

### DIFF
--- a/src/components/groups/add-member-dialog.tsx
+++ b/src/components/groups/add-member-dialog.tsx
@@ -64,7 +64,7 @@ export function MemberInviteFields({
 	selectedMembers,
 	onSelectedMembersChange,
 	excludeUserIds,
-	searchDebounceMs = 150,
+	searchDebounceMs = 50,
 	searchFieldLabel = "Search users",
 	shareLink,
 }: MemberInviteFieldsProps) {

--- a/src/components/groups/add-member-dialog.tsx
+++ b/src/components/groups/add-member-dialog.tsx
@@ -177,7 +177,9 @@ function MemberSearchAutocomplete({
 			value={null}
 			isOptionEqualToValue={(option, value) => option.id === value.id}
 			noOptionsText={
-				memberQuery.length < 2 ? "Type to search…" : "No users found"
+				memberQuery.length < 2
+					? "Search via Email, Display Name, Username..."
+					: "No users found"
 			}
 			slotProps={{
 				popper: {

--- a/src/components/groups/add-member-dialog.tsx
+++ b/src/components/groups/add-member-dialog.tsx
@@ -3,11 +3,7 @@
 import { inviteGroupMember } from "@actions/group/add-member/action";
 import { createGroupInvite } from "@actions/group/invite/create/action";
 import { inviteMeetingMembers } from "@actions/meeting/invite/action";
-import {
-	searchUsersDisplay,
-	searchUsersEmail,
-	searchUsersUsername,
-} from "@actions/user/search";
+import { searchUsers } from "@actions/user/search";
 import {
 	Autocomplete,
 	Avatar,
@@ -22,6 +18,8 @@ import {
 } from "@mui/material";
 import { Check, Copy } from "lucide-react";
 import {
+	type HTMLAttributes,
+	memo,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -60,30 +58,67 @@ type MemberInviteFieldsProps = {
 	shareLink?: MemberInviteShareLink | null;
 };
 
-export function MemberInviteFields({
-	selectedMembers,
-	onSelectedMembersChange,
+type MemberSearchAutocompleteProps = {
+	selectedMemberIds: Set<string>;
+	excludeUserIds: string[];
+	searchDebounceMs: number;
+	searchFieldLabel: string;
+	onSelectMember: (user: SearchUser) => void;
+};
+
+const MemberSearchOption = memo(function MemberSearchOption({
+	option,
+	...optionProps
+}: HTMLAttributes<HTMLLIElement> & { option: SearchUser }) {
+	return (
+		<li {...optionProps}>
+			<div className="flex items-center gap-3">
+				<Avatar
+					src={option.profilePicture ?? undefined}
+					slotProps={{
+						img: { referrerPolicy: "no-referrer" },
+					}}
+				>
+					{getInitials(option.email)}
+				</Avatar>
+				<div className="flex-col">
+					<Typography color="textPrimary" variant="button">
+						{option.displayName}
+					</Typography>
+					<div className="flex gap-1">
+						<Typography color="textSecondary" variant="caption">
+							{option.username ? `@${option.username} •` : ""}
+						</Typography>
+						<Typography color="textSecondary" variant="caption">
+							{option.email}
+						</Typography>
+					</div>
+				</div>
+			</div>
+		</li>
+	);
+});
+
+function MemberSearchAutocomplete({
+	selectedMemberIds,
 	excludeUserIds,
-	searchDebounceMs = 50,
-	searchFieldLabel = "Search users",
-	shareLink,
-}: MemberInviteFieldsProps) {
-	const { showError } = useSnackbar();
+	searchDebounceMs,
+	searchFieldLabel,
+	onSelectMember,
+}: MemberSearchAutocompleteProps) {
 	const [memberQuery, setMemberQuery] = useState("");
 	const [searchResults, setSearchResults] = useState<SearchUser[]>([]);
+	const [isSearching, startSearchTransition] = useTransition();
 	const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const latestQueryRef = useRef("");
-	const [copied, setCopied] = useState(false);
-	const copiedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+	const excludeSet = useMemo(() => new Set(excludeUserIds), [excludeUserIds]);
 
 	useEffect(() => {
 		return () => {
 			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
-			if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
 		};
 	}, []);
-
-	const excludeSet = useMemo(() => new Set(excludeUserIds), [excludeUserIds]);
 
 	const handleMemberSearch = useCallback(
 		(query: string) => {
@@ -95,33 +130,100 @@ export function MemberInviteFields({
 			}
 
 			if (query.length < 2) {
-				setSearchResults([]);
+				startSearchTransition(() => setSearchResults([]));
 				return;
 			}
 
-			searchTimeoutRef.current = setTimeout(async () => {
-				const [resultsEmail, resultsDisplay, resultsUser] = await Promise.all([
-					searchUsersEmail(query),
-					searchUsersDisplay(query),
-					searchUsersUsername(query),
-				]);
+			searchTimeoutRef.current = setTimeout(() => {
+				void (async () => {
+					const results = await searchUsers(query);
+					if (latestQueryRef.current !== query) return;
 
-				if (latestQueryRef.current !== query) return;
-				const seen = new Set<string>();
-				const results = [
-					...resultsDisplay,
-					...resultsUser,
-					...resultsEmail,
-				].filter((r) => {
-					if (seen.has(r.id)) return false;
-					seen.add(r.id);
-					return true;
-				});
-
-				setSearchResults(results.filter((r) => !excludeSet.has(r.id)));
+					startSearchTransition(() => {
+						setSearchResults(
+							results.filter(
+								(r) => !excludeSet.has(r.id) && !selectedMemberIds.has(r.id),
+							),
+						);
+					});
+				})();
 			}, searchDebounceMs);
 		},
-		[excludeSet, searchDebounceMs],
+		[excludeSet, searchDebounceMs, selectedMemberIds],
+	);
+
+	const options = useMemo(
+		() => searchResults.filter((user) => !selectedMemberIds.has(user.id)),
+		[searchResults, selectedMemberIds],
+	);
+
+	return (
+		<Autocomplete
+			options={options}
+			loading={isSearching}
+			getOptionLabel={(option) => option.email}
+			filterOptions={(x) => x}
+			inputValue={memberQuery}
+			onInputChange={(_, value, reason) => {
+				if (reason !== "reset") handleMemberSearch(value);
+			}}
+			onChange={(_, user) => {
+				if (user) {
+					onSelectMember(user);
+					setMemberQuery("");
+					setSearchResults([]);
+				}
+			}}
+			value={null}
+			isOptionEqualToValue={(option, value) => option.id === value.id}
+			noOptionsText={
+				memberQuery.length < 2 ? "Type to search…" : "No users found"
+			}
+			slotProps={{
+				popper: {
+					placement: "bottom-start",
+					modifiers: [{ name: "flip", enabled: false }],
+					sx: (theme) => ({ zIndex: theme.zIndex.modal + 1 }),
+				},
+			}}
+			renderInput={(params) => (
+				<TextField {...params} label={searchFieldLabel} size="small" />
+			)}
+			ListboxProps={{
+				style: { maxHeight: 140, overflowY: "auto" },
+			}}
+			renderOption={({ key, ...optionProps }, option) => (
+				<MemberSearchOption
+					key={key ?? option.id}
+					option={option}
+					{...optionProps}
+				/>
+			)}
+		/>
+	);
+}
+
+export function MemberInviteFields({
+	selectedMembers,
+	onSelectedMembersChange,
+	excludeUserIds,
+	searchDebounceMs = 100,
+	searchFieldLabel = "Search users",
+	shareLink,
+}: MemberInviteFieldsProps) {
+	const { showError } = useSnackbar();
+	const [copied, setCopied] = useState(false);
+	const copiedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+		};
+	}, []);
+
+	const selectedMemberIds = useMemo(
+		() => new Set(selectedMembers.map((m) => m.id)),
+		[selectedMembers],
 	);
 
 	const addMember = useCallback(
@@ -137,8 +239,6 @@ export function MemberInviteFields({
 					profilePicture: user.profilePicture ?? null,
 				},
 			]);
-			setMemberQuery("");
-			setSearchResults([]);
 		},
 		[selectedMembers, onSelectedMembersChange],
 	);
@@ -162,69 +262,14 @@ export function MemberInviteFields({
 		}
 	}, [shareLink?.url, showError]);
 
-	// Filter again at render time so members selected while a debounced search
-	// is in-flight are immediately hidden from the dropdown.
-	const options = searchResults.filter(
-		(user) => !selectedMembers.some((m) => m.id === user.id),
-	);
 	return (
 		<div className="flex flex-col gap-5 pt-1">
-			<Autocomplete
-				options={options}
-				getOptionLabel={(option) => option.email}
-				filterOptions={(x) => x}
-				inputValue={memberQuery}
-				onInputChange={(_, value, reason) => {
-					if (reason !== "reset") handleMemberSearch(value);
-				}}
-				onChange={(_, user) => {
-					if (user) addMember(user);
-				}}
-				value={null}
-				isOptionEqualToValue={(option, value) => option.id === value.id}
-				noOptionsText={
-					memberQuery.length < 2 ? "Type to search…" : "No users found"
-				}
-				slotProps={{
-					popper: {
-						placement: "bottom-start",
-						modifiers: [{ name: "flip", enabled: false }],
-						sx: (theme) => ({ zIndex: theme.zIndex.modal + 1 }),
-					},
-				}}
-				renderInput={(params) => (
-					<TextField {...params} label={searchFieldLabel} size="small" />
-				)}
-				ListboxProps={{
-					style: { maxHeight: 140, overflowY: "auto" },
-				}}
-				renderOption={({ key, ...optionProps }, option) => (
-					<li key={key ?? option.id} {...optionProps}>
-						<div className="flex items-center gap-3">
-							<Avatar
-								src={option.profilePicture ?? undefined}
-								slotProps={{
-									img: { referrerPolicy: "no-referrer" },
-								}}
-							>
-								{getInitials(option.email)}
-							</Avatar>
-							<div className="flex-col">
-								<Typography color="textPrimary" variant="button">
-									{option.displayName}
-								</Typography>
-								<div className="flex gap-1">
-									<Typography color="textSecondary" variant="caption">
-										{option.username ? `@${option.username} •` : ""}
-									</Typography>
-									<Typography color="textSecondary" variant="caption">
-										{option.email}
-									</Typography>
-								</div>
-							</div>
-						</div>
-					</li>
-				)}
+			<MemberSearchAutocomplete
+				selectedMemberIds={selectedMemberIds}
+				excludeUserIds={excludeUserIds}
+				searchDebounceMs={searchDebounceMs}
+				searchFieldLabel={searchFieldLabel}
+				onSelectMember={addMember}
 			/>
 
 			{selectedMembers.length > 0 && (

--- a/src/components/groups/create-group-dialog.tsx
+++ b/src/components/groups/create-group-dialog.tsx
@@ -215,7 +215,6 @@ export function CreateGroupDialog({
 						selectedMembers={members}
 						onSelectedMembersChange={setMembers}
 						excludeUserIds={[]}
-						searchDebounceMs={50}
 						searchFieldLabel="Add Members"
 						shareLink={{
 							url: inviteLink,

--- a/src/lib/sql/like-pattern.ts
+++ b/src/lib/sql/like-pattern.ts
@@ -1,0 +1,16 @@
+/** Trim and collapse internal whitespace for user-facing search input. */
+export function normalizeSearchQuery(query: string): string {
+	return query.trim().replace(/\s+/g, " ");
+}
+
+/** Escape `\`, `%`, and `_` so they match literally in SQL LIKE/ILIKE. */
+export function escapeLikePattern(query: string): string {
+	return query.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+/** Builds a `%term%` ILIKE pattern, or `null` when the normalized query is too short. */
+export function toIlikeContainsPattern(query: string): string | null {
+	const normalized = normalizeSearchQuery(query);
+	if (normalized.length < 2) return null;
+	return `%${escapeLikePattern(normalized)}%`;
+}

--- a/src/server/actions/user/search.ts
+++ b/src/server/actions/user/search.ts
@@ -4,8 +4,16 @@ import { getCurrentSession } from "@/lib/auth";
 import {
 	searchUsersByDisplayName,
 	searchUsersByEmail,
+	searchUsersByQuery,
 	searchUsersByUsername,
 } from "@/server/data/user/queries";
+
+export async function searchUsers(query: string) {
+	const { user } = await getCurrentSession();
+	if (!user) return [];
+
+	return searchUsersByQuery(query, user.id);
+}
 
 export async function searchUsersEmail(query: string) {
 	const { user } = await getCurrentSession();

--- a/src/server/data/user/queries.ts
+++ b/src/server/data/user/queries.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, ilike, inArray, ne } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, ne, or } from "drizzle-orm";
 import { db } from "@/db";
 import { groups, members, notifications, users } from "@/db/schema";
 import { sendEmail } from "@/lib/email/send-email";
@@ -32,6 +32,41 @@ export async function getUserById(id: string) {
 	});
 
 	return user ?? null;
+}
+
+const userSearchSelect = {
+	id: users.id,
+	email: users.email,
+	username: members.username,
+	displayName: members.displayName,
+	profilePicture: members.profilePicture,
+} as const;
+
+/** Single query across email, username, and display name. */
+export async function searchUsersByQuery(
+	query: string,
+	excludeUserId: string,
+	limit = 15,
+) {
+	if (!query || query.length < 2) return [];
+
+	const pattern = `%${query}%`;
+
+	return await db
+		.select(userSearchSelect)
+		.from(users)
+		.innerJoin(members, eq(users.memberId, members.id))
+		.where(
+			and(
+				ne(users.id, excludeUserId),
+				or(
+					ilike(users.email, pattern),
+					ilike(members.username, pattern),
+					ilike(members.displayName, pattern),
+				),
+			),
+		)
+		.limit(limit);
 }
 
 export async function searchUsersByUsername(

--- a/src/server/data/user/queries.ts
+++ b/src/server/data/user/queries.ts
@@ -1,9 +1,10 @@
 import "server-only";
 
-import { and, desc, eq, ilike, inArray, ne, or } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, or, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { groups, members, notifications, users } from "@/db/schema";
 import { sendEmail } from "@/lib/email/send-email";
+import { toIlikeContainsPattern } from "@/lib/sql/like-pattern";
 
 export async function getUserIdExists(id: string) {
 	const user = await db.query.users.findFirst({
@@ -48,9 +49,8 @@ export async function searchUsersByQuery(
 	excludeUserId: string,
 	limit = 15,
 ) {
-	if (!query || query.length < 2) return [];
-
-	const pattern = `%${query}%`;
+	const pattern = toIlikeContainsPattern(query);
+	if (!pattern) return [];
 
 	return await db
 		.select(userSearchSelect)
@@ -60,9 +60,9 @@ export async function searchUsersByQuery(
 			and(
 				ne(users.id, excludeUserId),
 				or(
-					ilike(users.email, pattern),
-					ilike(members.username, pattern),
-					ilike(members.displayName, pattern),
+					sql`${users.email} ILIKE ${pattern} ESCAPE '\\'`,
+					sql`${members.username} ILIKE ${pattern} ESCAPE '\\'`,
+					sql`${members.displayName} ILIKE ${pattern} ESCAPE '\\'`,
 				),
 			),
 		)
@@ -74,30 +74,8 @@ export async function searchUsersByUsername(
 	excludeUserId: string,
 	limit = 5,
 ) {
-	if (!query || query.length < 2) return [];
-
-	return await db
-		.select({
-			id: users.id,
-			email: users.email,
-			username: members.username,
-			displayName: members.displayName,
-			profilePicture: members.profilePicture,
-		})
-		.from(users)
-		.innerJoin(members, eq(users.memberId, members.id))
-		.where(
-			and(ilike(members.username, `%${query}%`), ne(users.id, excludeUserId)),
-		)
-		.limit(limit);
-}
-
-export async function searchUsersByDisplayName(
-	query: string,
-	excludeUserId: string,
-	limit = 5,
-) {
-	if (!query || query.length < 2) return [];
+	const pattern = toIlikeContainsPattern(query);
+	if (!pattern) return [];
 
 	return await db
 		.select({
@@ -111,18 +89,20 @@ export async function searchUsersByDisplayName(
 		.innerJoin(members, eq(users.memberId, members.id))
 		.where(
 			and(
-				ilike(members.displayName, `%${query}%`),
+				sql`${members.username} ILIKE ${pattern} ESCAPE '\\'`,
 				ne(users.id, excludeUserId),
 			),
 		)
 		.limit(limit);
 }
-export async function searchUsersByEmail(
+
+export async function searchUsersByDisplayName(
 	query: string,
 	excludeUserId: string,
 	limit = 5,
 ) {
-	if (!query || query.length < 2) return [];
+	const pattern = toIlikeContainsPattern(query);
+	if (!pattern) return [];
 
 	return await db
 		.select({
@@ -134,7 +114,38 @@ export async function searchUsersByEmail(
 		})
 		.from(users)
 		.innerJoin(members, eq(users.memberId, members.id))
-		.where(and(ilike(users.email, `%${query}%`), ne(users.id, excludeUserId)))
+		.where(
+			and(
+				sql`${members.displayName} ILIKE ${pattern} ESCAPE '\\'`,
+				ne(users.id, excludeUserId),
+			),
+		)
+		.limit(limit);
+}
+export async function searchUsersByEmail(
+	query: string,
+	excludeUserId: string,
+	limit = 5,
+) {
+	const pattern = toIlikeContainsPattern(query);
+	if (!pattern) return [];
+
+	return await db
+		.select({
+			id: users.id,
+			email: users.email,
+			username: members.username,
+			displayName: members.displayName,
+			profilePicture: members.profilePicture,
+		})
+		.from(users)
+		.innerJoin(members, eq(users.memberId, members.id))
+		.where(
+			and(
+				sql`${users.email} ILIKE ${pattern} ESCAPE '\\'`,
+				ne(users.id, excludeUserId),
+			),
+		)
 		.limit(limit);
 }
 


### PR DESCRIPTION
## Description
 
user search is too slow. this pr consolidates 3 server actions (searchUsersEmail, searchUserDisplay, searchUsersUsername) that fires per render. 

before / after
<img width="202" height="111" alt="image" src="https://github.com/user-attachments/assets/5c726942-e140-4b1d-a086-98a53f03eb0b" />

<img width="586" height="148" alt="image" src="https://github.com/user-attachments/assets/0e0f2788-9d82-413c-a5bf-2d5aa40f7d14" />


changes: 
- single searchUsers action 
- isolated MemberSearchAutocomplete
- useTransition for results
- added email, username, displayname placeholder to input 