### PR TITLE
chore: round corners & hide banners on past cards

### DIFF
--- a/src/components/summary/meetings.tsx
+++ b/src/components/summary/meetings.tsx
@@ -62,6 +62,7 @@ const toCard = (
 	memberId: string,
 	meetingCounts: Record<string, number>,
 	onDeleteLeave: (target: DeleteTarget) => void,
+	isPast?: boolean,
 	scheduledLabels?: Record<string, string>,
 	upcomingSet?: Set<string>,
 ) => {
@@ -81,6 +82,7 @@ const toCard = (
 			needsAvailability={meeting.needsAvailability}
 			allAvailabilityFilled={meeting.allAvailabilityFilled}
 			isUpcoming={upcomingSet?.has(meeting.id) ?? false}
+			isPast={isPast}
 			onDeleteLeave={() =>
 				onDeleteLeave({ meeting, isOwner: cardProps.isOwner })
 			}
@@ -212,6 +214,7 @@ export const Meetings = ({
 						memberId,
 						meetingCounts,
 						handleDeleteLeaveRequest,
+						activeFilter === "past",
 						scheduledLabels,
 						upcomingSet,
 					),

--- a/src/components/ui/meeting-card.tsx
+++ b/src/components/ui/meeting-card.tsx
@@ -26,6 +26,7 @@ interface MeetingCardProps extends MeetingCardViewModel {
 	needsAvailability?: boolean;
 	allAvailabilityFilled?: boolean;
 	isUpcoming?: boolean;
+	isPast?: boolean;
 }
 
 const metaIconSx = { fontSize: 16, color: "text.secondary", flexShrink: 0 };
@@ -78,6 +79,7 @@ const MeetingCard = ({
 	needsAvailability = false,
 	allAvailabilityFilled = false,
 	isUpcoming = false,
+	isPast = false,
 }: MeetingCardProps) => {
 	const menuId = useId();
 	const { label: actionLabel, Icon, menuColor } = getDeleteLeaveAction(isOwner);
@@ -95,15 +97,17 @@ const MeetingCard = ({
 		onDeleteLeave?.();
 	};
 
-	const variant = needsAvailability
-		? "action-required"
-		: !scheduled && allAvailabilityFilled && isOwner
-			? "schedule-alert"
-			: scheduled && isUpcoming
-				? "upcoming"
-				: scheduled
-					? "scheduled"
-					: "default";
+	const variant = isPast
+		? "default"
+		: needsAvailability
+			? "action-required"
+			: !scheduled && allAvailabilityFilled && isOwner
+				? "schedule-alert"
+				: scheduled && isUpcoming
+					? "upcoming"
+					: scheduled
+						? "scheduled"
+						: "default";
 
 	const cardContent = (
 		<CardContent

--- a/src/components/ui/meeting-card.tsx
+++ b/src/components/ui/meeting-card.tsx
@@ -298,8 +298,6 @@ const MeetingCard = ({
 				sx={{
 					display: "flex",
 					flexDirection: "column",
-					borderBottomLeftRadius: 0,
-					borderBottomRightRadius: 0,
 				}}
 			>
 				{cardContent}


### PR DESCRIPTION
## Description
Round corners of meeting cards according to Figma. Remove banners from meetings in the past. 

## Recording/Screenshots

### Round Corners

#### Before
<img width="494" height="260" alt="image" src="https://github.com/user-attachments/assets/b81b4709-167a-4977-82f4-4dc619f1fceb" />

#### After
<img width="495" height="255" alt="image" src="https://github.com/user-attachments/assets/4b72b3da-f2c5-4f47-bb11-acf4322232d4" />

### Past Meetings

#### Before
<img width="1512" height="814" alt="image" src="https://github.com/user-attachments/assets/eac82429-51d2-4d48-b4d4-e6813abb7507" />

#### After

<img width="1486" height="795" alt="image" src="https://github.com/user-attachments/assets/07dc4f46-db66-47ca-b435-7cc5c7b0a135" />


## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #

<!-- ## Future Follow-Up -->
