### PR TITLE
feat: ✨ meeting dynamic metadata

### DIFF
--- a/src/app/availability/[slug]/page.tsx
+++ b/src/app/availability/[slug]/page.tsx
@@ -36,7 +36,12 @@ export async function generateMetadata(props: PageProps) {
 		notFound();
 	}
 
-	const hostName = getMeetingHostDisplayName(meetingData.hostDisplayName);
+	const hostName = getMeetingHostDisplayName({
+		hostDisplayName: meetingData.hostDisplayName,
+		hostUsername: meetingData.hostUsername,
+		hostGoogleName: meetingData.hostGoogleName,
+		hostEmail: meetingData.hostEmail,
+	});
 	const shareTitle = `${hostName} is requesting your availability for ${meetingData.title}`;
 
 	return {

--- a/src/app/availability/[slug]/page.tsx
+++ b/src/app/availability/[slug]/page.tsx
@@ -2,15 +2,11 @@ import { notFound } from "next/navigation";
 import { Availability } from "@/components/availability/availability";
 import { getCurrentSession } from "@/lib/auth";
 import {
-	formatDateToUSNumeric,
-	sortMeetingIsoDatesAsc,
-} from "@/lib/availability/utils";
-import {
 	OPEN_INVITE_AFTER_CREATE_PARAM,
 	OPEN_INVITE_AFTER_CREATE_VALUE,
 } from "@/lib/meeting-open-invite";
 import { getMeetingHostDisplayName } from "@/lib/meetings/utils";
-import { APP_DESCRIPTION } from "@/lib/pwa-config.mjs";
+import { APP_DESCRIPTION, APP_NAME } from "@/lib/pwa-config.mjs";
 import {
 	getAllMemberAvailability,
 	getExistingMeeting,
@@ -40,7 +36,8 @@ export async function generateMetadata(props: PageProps) {
 		notFound();
 	}
 
-	const hostName = getMeetingHostDisplayName(meetingData.hostId);
+	const hostName = getMeetingHostDisplayName(meetingData.hostDisplayName);
+	const shareTitle = `${hostName} is requesting your availability for ${meetingData.title}`;
 
 	return {
 		title: {
@@ -48,18 +45,18 @@ export async function generateMetadata(props: PageProps) {
 			absolute: `Availability for ${meetingData.title}`,
 		},
 		openGraph: {
-			title: `${hostName} is requesting your availability for ${meetingData.title}`,
+			title: shareTitle,
 			description: APP_DESCRIPTION,
 			url: `/availability/${slug}`,
 			type: "website",
-			siteName: "ZotMeet",
+			siteName: APP_NAME,
 			images: [
-				{ url: "/icons/icon-512.png", width: 512, height: 512, alt: "ZotMeet" },
+				{ url: "/icons/icon-512.png", width: 512, height: 512, alt: APP_NAME },
 			],
 		},
 		twitter: {
 			card: "summary",
-			title: `${hostName} is requesting your availability for ${meetingData.title}`,
+			title: shareTitle,
 			description: APP_DESCRIPTION,
 			images: ["/icons/icon-512.png"],
 		},

--- a/src/app/availability/[slug]/page.tsx
+++ b/src/app/availability/[slug]/page.tsx
@@ -39,6 +39,22 @@ export async function generateMetadata(props: PageProps) {
 			default: "View Meeting Availability",
 			absolute: `Availability for ${meetingData.title}`,
 		},
+		openGraph: {
+			title: `Availability for ${meetingData.title}`,
+			description: `${meetingData.dates}`,
+			url: `/availability/${slug}`,
+			type: "website",
+			siteName: "ZotMeet",
+			images: [
+				{ url: "/icons/icon-512.png", width: 512, height: 512, alt: "ZotMeet" },
+			],
+		},
+		twitter: {
+			card: "summary",
+			title: `Availability for ${meetingData.title}`,
+			description: `${meetingData.dates}`,
+			images: ["/icons/icon-512.png"],
+		},
 		description: `Specify Meeting Availability for ${meetingData.title}`,
 	};
 }

--- a/src/app/availability/[slug]/page.tsx
+++ b/src/app/availability/[slug]/page.tsx
@@ -2,9 +2,15 @@ import { notFound } from "next/navigation";
 import { Availability } from "@/components/availability/availability";
 import { getCurrentSession } from "@/lib/auth";
 import {
+	formatDateToUSNumeric,
+	sortMeetingIsoDatesAsc,
+} from "@/lib/availability/utils";
+import {
 	OPEN_INVITE_AFTER_CREATE_PARAM,
 	OPEN_INVITE_AFTER_CREATE_VALUE,
 } from "@/lib/meeting-open-invite";
+import { getMeetingHostDisplayName } from "@/lib/meetings/utils";
+import { APP_DESCRIPTION } from "@/lib/pwa-config.mjs";
 import {
 	getAllMemberAvailability,
 	getExistingMeeting,
@@ -34,14 +40,16 @@ export async function generateMetadata(props: PageProps) {
 		notFound();
 	}
 
+	const hostName = getMeetingHostDisplayName(meetingData.hostId);
+
 	return {
 		title: {
 			default: "View Meeting Availability",
 			absolute: `Availability for ${meetingData.title}`,
 		},
 		openGraph: {
-			title: `Availability for ${meetingData.title}`,
-			description: `${meetingData.dates}`,
+			title: `${hostName} is requesting your availability for ${meetingData.title}`,
+			description: APP_DESCRIPTION,
 			url: `/availability/${slug}`,
 			type: "website",
 			siteName: "ZotMeet",
@@ -51,8 +59,8 @@ export async function generateMetadata(props: PageProps) {
 		},
 		twitter: {
 			card: "summary",
-			title: `Availability for ${meetingData.title}`,
-			description: `${meetingData.dates}`,
+			title: `${hostName} is requesting your availability for ${meetingData.title}`,
+			description: APP_DESCRIPTION,
 			images: ["/icons/icon-512.png"],
 		},
 		description: `Specify Meeting Availability for ${meetingData.title}`,

--- a/src/lib/meeting-card/mapper.ts
+++ b/src/lib/meeting-card/mapper.ts
@@ -103,7 +103,9 @@ export function toMeetingCardProps(
 
 	return {
 		meetingName: meeting.title,
-		meetingOrganizer: getMeetingHostDisplayName(meeting.hostDisplayName),
+		meetingOrganizer: getMeetingHostDisplayName({
+			hostDisplayName: meeting.hostDisplayName,
+		}),
 		dateStart: formatDateForMeetingType(firstDate, meeting.meetingType),
 		dateEnd: formatDateForMeetingType(lastDate, meeting.meetingType),
 		timeStart: formatTime(localFromTime),

--- a/src/lib/meeting-card/mapper.ts
+++ b/src/lib/meeting-card/mapper.ts
@@ -1,5 +1,6 @@
 import type { SelectMeeting } from "@/db/schema";
 import { convertTimeFromUTC } from "@/lib/availability/utils";
+import { getMeetingHostDisplayName } from "@/lib/meetings/utils";
 import { WEEKDAYS } from "@/lib/types/chrono";
 
 export interface MeetingCardViewModel {
@@ -102,7 +103,7 @@ export function toMeetingCardProps(
 
 	return {
 		meetingName: meeting.title,
-		meetingOrganizer: meeting.hostDisplayName ?? "Unknown organizer",
+		meetingOrganizer: getMeetingHostDisplayName(meeting.hostDisplayName),
 		dateStart: formatDateForMeetingType(firstDate, meeting.meetingType),
 		dateEnd: formatDateForMeetingType(lastDate, meeting.meetingType),
 		timeStart: formatTime(localFromTime),

--- a/src/lib/meetings/utils.ts
+++ b/src/lib/meetings/utils.ts
@@ -2,6 +2,14 @@ import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 
 const UPCOMING_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
+/** Resolved host label for cards, metadata, etc. */
+export function getMeetingHostDisplayName(
+	hostDisplayName: string | null | undefined,
+): string {
+	const trimmed = hostDisplayName?.trim();
+	return trimmed || "Unknown organizer";
+}
+
 export function getStartOfTodayMs(): number {
 	const d = new Date();
 	d.setHours(0, 0, 0, 0);

--- a/src/lib/meetings/utils.ts
+++ b/src/lib/meetings/utils.ts
@@ -2,12 +2,47 @@ import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 
 const UPCOMING_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+	return UUID_RE.test(value);
+}
+
+export type MeetingHostNameFields = {
+	hostDisplayName?: string | null;
+	hostUsername?: string | null;
+	hostGoogleName?: string | null;
+	hostEmail?: string | null;
+};
+
+function emailLocalPart(email: string | null | undefined): string | null {
+	const trimmed = email?.trim();
+	if (!trimmed?.includes("@")) return null;
+	const local = trimmed.split("@")[0]?.trim();
+	return local || null;
+}
+
 /** Resolved host label for cards, metadata, etc. */
 export function getMeetingHostDisplayName(
-	hostDisplayName: string | null | undefined,
+	host: MeetingHostNameFields | string | null | undefined,
 ): string {
-	const trimmed = hostDisplayName?.trim();
-	return trimmed || "Unknown organizer";
+	const fields =
+		typeof host === "string" || host == null ? { hostDisplayName: host } : host;
+
+	for (const candidate of [
+		fields.hostDisplayName,
+		fields.hostGoogleName,
+		fields.hostUsername,
+		emailLocalPart(fields.hostEmail),
+	]) {
+		const trimmed = candidate?.trim();
+		if (trimmed && !isUuid(trimmed)) {
+			return trimmed;
+		}
+	}
+
+	return "Unknown organizer";
 }
 
 export function getStartOfTodayMs(): number {

--- a/src/lib/meetings/utils.ts
+++ b/src/lib/meetings/utils.ts
@@ -3,7 +3,7 @@ import type { SelectMeeting, SelectScheduledMeeting } from "@/db/schema";
 const UPCOMING_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
 const UUID_RE =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isUuid(value: string): boolean {
 	return UUID_RE.test(value);

--- a/src/lib/pwa-config.mjs
+++ b/src/lib/pwa-config.mjs
@@ -15,7 +15,7 @@
 export const APP_NAME = "ZotMeet";
 
 export const APP_DESCRIPTION =
-	"ZotMeet is a simple, clean, and efficient meeting scheduling app for UCI students and groups.";
+	"Schedule Meetings, Book UCI Rooms, and Time Sync with ZotMeet";
 
 /**
  * Canonical public origin for metadata, sitemap, and store manifests.

--- a/src/server/data/meeting/queries.ts
+++ b/src/server/data/meeting/queries.ts
@@ -21,12 +21,36 @@ import {
 } from "@/db/schema";
 import type { MemberMeetingAvailability } from "@/lib/types/availability";
 
+export type MeetingWithHost = SelectMeeting & {
+	hostDisplayName: string | null;
+};
+
 export async function getExistingMeeting(
 	meetingId: string,
-): Promise<SelectMeeting> {
-	const meeting = await db.query.meetings.findFirst({
-		where: and(eq(meetings.id, meetingId), eq(meetings.archived, false)),
-	});
+): Promise<MeetingWithHost> {
+	const [meeting] = await db
+		.select({
+			id: meetings.id,
+			title: meetings.title,
+			description: meetings.description,
+			location: meetings.location,
+			scheduled: meetings.scheduled,
+			fromTime: meetings.fromTime,
+			toTime: meetings.toTime,
+			timezone: meetings.timezone,
+			group_id: meetings.group_id,
+			hostId: meetings.hostId,
+			dates: meetings.dates,
+			meetingType: meetings.meetingType,
+			createdAt: meetings.createdAt,
+			archived: meetings.archived,
+			membersCanInvite: meetings.membersCanInvite,
+			hostDisplayName: members.displayName,
+		})
+		.from(meetings)
+		.leftJoin(members, eq(meetings.hostId, members.id))
+		.where(and(eq(meetings.id, meetingId), eq(meetings.archived, false)))
+		.limit(1);
 
 	if (!meeting) {
 		throw new Error("Meeting not found");

--- a/src/server/data/meeting/queries.ts
+++ b/src/server/data/meeting/queries.ts
@@ -18,11 +18,15 @@ import {
 	members,
 	type SelectMeeting,
 	scheduledMeetings,
+	users,
 } from "@/db/schema";
 import type { MemberMeetingAvailability } from "@/lib/types/availability";
 
 export type MeetingWithHost = SelectMeeting & {
 	hostDisplayName: string | null;
+	hostUsername: string | null;
+	hostGoogleName: string | null;
+	hostEmail: string | null;
 };
 
 export async function getExistingMeeting(
@@ -46,9 +50,13 @@ export async function getExistingMeeting(
 			archived: meetings.archived,
 			membersCanInvite: meetings.membersCanInvite,
 			hostDisplayName: members.displayName,
+			hostUsername: members.username,
+			hostGoogleName: members.googleName,
+			hostEmail: users.email,
 		})
 		.from(meetings)
 		.leftJoin(members, eq(meetings.hostId, members.id))
+		.leftJoin(users, eq(users.memberId, members.id))
 		.where(and(eq(meetings.id, meetingId), eq(meetings.archived, false)))
 		.limit(1);
 


### PR DESCRIPTION
## Description

Adds dynamic metadate to meeting links (/availability/[slug])

Examples are from Discord and iMessages

### Before
<img width="669" height="150" alt="image" src="https://github.com/user-attachments/assets/190b4661-5c02-4841-8d52-2e6b824257e6" />
<img width="289" height="358" alt="image" src="https://github.com/user-attachments/assets/5c3433b9-46e5-4ba2-85e5-8697312c6f29" />


### After
<img width="669" height="150" alt="image" src="https://github.com/user-attachments/assets/47d61701-fa2b-42f0-ac85-f514f4c901d4" />
<img width="289" height="358" alt="image" src="https://github.com/user-attachments/assets/97b845ea-134c-44f8-9f54-b39ba80e0452" />


- Closes #
https://github.com/icssc/ZotMeet/issues/548

<!-- ## Future Follow-Up -->
