### PR TITLE
style: 🎨 match buttons to figma

### DIFF
--- a/src/components/availability/availability-actions.tsx
+++ b/src/components/availability/availability-actions.tsx
@@ -74,7 +74,6 @@ export function AvailabilityActions({
 				<div className="hidden flex-row flex-wrap justify-end gap-2 sm:flex">
 					<Button
 						variant="outlined"
-						color="inherit"
 						size="small"
 						onClick={
 							availabilityView === "personal"
@@ -100,7 +99,6 @@ export function AvailabilityActions({
 						<div className="hidden flex-col sm:flex">
 							<Button
 								variant="outlined"
-								color="inherit"
 								size="medium"
 								startIcon={<GoogleIcon sx={{ fontSize: 18 }} />}
 								onClick={async () => {
@@ -167,7 +165,6 @@ export function AvailabilityActions({
 						{isOwner && (
 							<Button
 								variant="outlined"
-								color="inherit"
 								startIcon={<Event />}
 								className="w-full"
 								sx={{ py: 0.75 }}
@@ -179,7 +176,6 @@ export function AvailabilityActions({
 						{canShowInviteButton && (
 							<Button
 								variant="outlined"
-								color="inherit"
 								startIcon={<GroupAddOutlined />}
 								className="w-full"
 								sx={{ py: 0.75 }}

--- a/src/components/availability/availability-actions.tsx
+++ b/src/components/availability/availability-actions.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { getGoogleCalendarPrefilledLink } from "@actions/availability/google/calendar/action";
-import {
-	Create,
-	GroupAddOutlined,
-	InsertInvitationRounded,
-} from "@mui/icons-material";
+import { Create, Event, GroupAddOutlined } from "@mui/icons-material";
 import GoogleIcon from "@mui/icons-material/Google";
 import { Button } from "@mui/material";
 import { useRouter } from "next/navigation";
@@ -104,6 +100,7 @@ export function AvailabilityActions({
 						<div className="hidden flex-col sm:flex">
 							<Button
 								variant="outlined"
+								color="inherit"
 								size="medium"
 								startIcon={<GoogleIcon sx={{ fontSize: 18 }} />}
 								onClick={async () => {
@@ -166,11 +163,12 @@ export function AvailabilityActions({
 							</span>
 						</Button>
 					</div>
-					<div className="hidden sm:block">
+					<div className="hidden sm:flex sm:flex-col sm:gap-2">
 						{isOwner && (
 							<Button
 								variant="outlined"
-								startIcon={<InsertInvitationRounded />}
+								color="inherit"
+								startIcon={<Event />}
 								className="w-full"
 								sx={{ py: 0.75 }}
 								onClick={() => setAvailabilityView("schedule")}
@@ -181,6 +179,7 @@ export function AvailabilityActions({
 						{canShowInviteButton && (
 							<Button
 								variant="outlined"
+								color="inherit"
 								startIcon={<GroupAddOutlined />}
 								className="w-full"
 								sx={{ py: 0.75 }}

--- a/src/components/availability/header/edit-modal.tsx
+++ b/src/components/availability/header/edit-modal.tsx
@@ -159,11 +159,7 @@ export const EditModal = ({
 				</Button>
 
 				<div className="flex gap-2">
-					<Button
-						variant="outlined"
-						color="inherit"
-						onClick={() => handleOpenChange(false)}
-					>
+					<Button variant="outlined" onClick={() => handleOpenChange(false)}>
 						Cancel
 					</Button>
 					<Button

--- a/src/components/availability/schedule-meeting-settings.tsx
+++ b/src/components/availability/schedule-meeting-settings.tsx
@@ -39,7 +39,6 @@ export function ScheduleMeetingSettings({
 			<div className="flex flex-col gap-12 px-6">
 				<Button
 					variant="outlined"
-					color="inherit"
 					fullWidth
 					startIcon={<AutorenewRounded sx={{ fontSize: 18 }} />}
 					onClick={() => replaceEntireSelection([])}
@@ -49,7 +48,6 @@ export function ScheduleMeetingSettings({
 				<div className="flex justify-end gap-2">
 					<Button
 						variant="outlined"
-						color="inherit"
 						size="small"
 						onClick={handleScheduleCancel}
 					>

--- a/src/components/nav/mui-top-nav.tsx
+++ b/src/components/nav/mui-top-nav.tsx
@@ -242,7 +242,6 @@ function Notifications({
 										</Box>
 										<Button
 											variant="outlined"
-											color="inherit"
 											size="small"
 											sx={{ ml: "auto", my: 2 }}
 											onClick={() =>

--- a/src/components/nav/personal-availability-sidebar.tsx
+++ b/src/components/nav/personal-availability-sidebar.tsx
@@ -251,7 +251,6 @@ export function PersonalAvailabilitySidebar({
 
 					<Button
 						variant="outlined"
-						color="inherit"
 						fullWidth
 						disabled={!canImport}
 						onClick={onClearAvailability}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -245,10 +245,14 @@ export const getTheme = (mode: "light" | "dark") =>
 							backgroundColor: theme.palette.secondary.main,
 						},
 					}),
-					outlined: {
-						boxShadow: "0px 3px 0px 0px rgba(0,0,0,0.25)",
+					outlined: ({ theme }) => ({
+						color: theme.palette.text.primary,
+						borderColor: "rgba(0,0,0,0.25)",
+						backgroundColor: theme.palette.background.paper,
+
+						boxShadow: "0px 4px 0px 0px rgba(0,0,0,0.25)",
 						"&:hover": {
-							boxShadow: "0px 1px 0px 0px rgba(0,0,0,0.25)",
+							boxShadow: "0px 2px 0px 0px rgba(0,0,0,0.25)",
 							transform: "translateY(2px)",
 							backgroundColor: "transparent",
 						},
@@ -256,9 +260,8 @@ export const getTheme = (mode: "light" | "dark") =>
 							boxShadow: "none",
 							transform: "translateY(4px)",
 						},
-					},
+					}),
 					outlinedPrimary: ({ theme }) => ({
-						borderColor: `rgba(242, 100, 137, 0.5)`,
 						"&:hover": {
 							borderColor: theme.palette.primary.main,
 						},

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -246,9 +246,9 @@ export const getTheme = (mode: "light" | "dark") =>
 						},
 					}),
 					outlined: {
-						boxShadow: "0px 4px 0px 0px rgba(0,0,0,0.25)",
+						boxShadow: "0px 3px 0px 0px rgba(0,0,0,0.25)",
 						"&:hover": {
-							boxShadow: "0px 2px 0px 0px rgba(0,0,0,0.25)",
+							boxShadow: "0px 1px 0px 0px rgba(0,0,0,0.25)",
 							transform: "translateY(2px)",
 							backgroundColor: "transparent",
 						},

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -247,7 +247,10 @@ export const getTheme = (mode: "light" | "dark") =>
 					}),
 					outlined: ({ theme }) => ({
 						color: theme.palette.text.primary,
-						borderColor: "rgba(0,0,0,0.25)",
+						borderColor:
+							theme.palette.mode === "dark"
+								? "rgba(255,255,255,0.25)"
+								: "rgba(0,0,0,0.25)",
 						backgroundColor: theme.palette.background.paper,
 
 						boxShadow: "0px 4px 0px 0px rgba(0,0,0,0.25)",
@@ -275,12 +278,6 @@ export const getTheme = (mode: "light" | "dark") =>
 							color: theme.palette.secondary.contrastText,
 							borderColor: theme.palette.secondary.main,
 						},
-					}),
-					outlinedInherit: ({ theme }) => ({
-						borderColor:
-							theme.palette.mode === "dark"
-								? "rgba(255,255,255,0.3)"
-								: "rgba(0,0,0,0.3)",
 					}),
 				},
 			},


### PR DESCRIPTION
## Description
Update meeting buttons to match Figma, including color and spacing. 

Figma ref:
<img width="619" height="159" alt="image" src="https://github.com/user-attachments/assets/edb93dce-d6fc-4db2-ab48-8fea12bb60cd" />

## Recording/Screenshots

### Before
<img width="808" height="370" alt="image" src="https://github.com/user-attachments/assets/29e3376a-3dac-41e0-b4d4-66844a603841" />

### After
<img width="806" height="381" alt="image" src="https://github.com/user-attachments/assets/b1ebd3d8-eeb4-49c2-8a36-8979affcdd28" />

## Test Plan

<!-- What to do to make sure that the feature works? -->

## Issues

<!-- What issues are related to or will be closed by this PR? -->
<!-- This section is **not** for issues you personally ran into, or any which you expect to occur -->

- Closes #

<!-- ## Future Follow-Up -->
