### PR TITLE
fix: 🐛 abbreviating building names showing where full names should be

### DIFF
--- a/src/components/studyrooms/heatmap/rooms-heatmap.tsx
+++ b/src/components/studyrooms/heatmap/rooms-heatmap.tsx
@@ -186,7 +186,7 @@ export const RoomsHeatmap = ({
 											backgroundColor: theme.palette.background.paper,
 										})}
 									>
-										<p className="">{formatLocation(room.location)}</p>
+										<p className="">{room.location}</p>
 										<div className="flex items-center gap-2 text-xs">
 											<p className="text-xs">{room.name?.slice(0, 20)}</p>
 											<p>{room.capacity ? `•  Cap: ${room.capacity}` : null}</p>

--- a/src/components/studyrooms/room-results.tsx
+++ b/src/components/studyrooms/room-results.tsx
@@ -54,7 +54,7 @@ export function RoomResults({ rooms, startTime, endTime }: RoomResultsProps) {
 						<Stack direction="row" alignItems="center" spacing={1}>
 							<Typography fontWeight="bold">{room.name}</Typography>
 							<Typography variant="body2" color="text.secondary">
-								— {formatLocation(room.location)}, capacity {room.capacity}
+								— {room.location}, capacity {room.capacity}
 								{room.techEnhanced && " (tech enhanced)"}
 							</Typography>
 							<Button

--- a/src/components/studyrooms/sidebar.tsx
+++ b/src/components/studyrooms/sidebar.tsx
@@ -321,12 +321,14 @@ export function Sidebar({
 						freeSolo
 						options={BUILDINGS}
 						value={location}
-						getOptionLabel={(opt) =>
-							typeof opt === "string" ? formatLocation(opt) : opt
-						}
+						getOptionLabel={(opt) => (typeof opt === "string" ? opt : opt)}
 						onChange={(_, val) => setLocation(val)}
 						onInputChange={(_, val, reason) => {
 							if (reason !== "reset") setLocation(val || null);
+						}}
+						// Limit the height of the dropdown list, so it doesnt move up
+						slotProps={{
+							listbox: { sx: { maxHeight: 240, overflow: "auto" } },
 						}}
 						renderInput={(params) => (
 							<TextField {...params} label="Location" fullWidth />


### PR DESCRIPTION
## Description

Building names were unexpectedly abbreviated ("Sci Lib", "MRC", "ALP") in the room results list and the location search dropdown. The abbreviation was only meant for the room recommendation chips, where horizontal space is tight — the results list and dropdown have room to show full names.

Fixed by:
- `room-results.tsx`: use `room.location` directly instead of `formatLocation(room.location)`
- `sidebar.tsx`: removed the abbreviating `getOptionLabel` from the Location Autocomplete so it displays the full `BUILDINGS` names
- Capped the Autocomplete's dropdown height (`slotProps.listbox`) so the longer full names don't push the mobile bottom sheet's layout around when the dropdown opens


## Test Plan

1. Open the study rooms page, search for rooms
2. Confirm room results list shows full building names (e.g. "Science Library" instead of "Sci Lib")
3. Open the Location filter dropdown, confirm full building names are listed
4. Confirm room recommendation chips still show abbreviated names (unchanged, by design)
5. On mobile, confirm the bottom sheet doesn't shift position when the Location dropdown opens

## Issues

- Closes #566 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/icssc/ZotMeet/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

